### PR TITLE
Create data folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ pre-config: pre-init ## Initialise env files, and create some required folders, 
 
 pre-init:
 	@ln -sfn $(FLAVOUR_PATH)/config ./config
+	@mkdir -p data/
 	@ln -sf $(FLAVOUR_PATH) ./data/current_flavour
 	@mkdir -p config/prod
 	@mkdir -p config/dev


### PR DESCRIPTION
When cloning this project from scratch and running `make pre-config`, it gave the following error:

`ln: failed to create symbolic link './data/current_flavour': No such file or directory`

This is a result of the `data` folder being unable to be created automatically, as explained [here](https://unix.stackexchange.com/a/668367/370076). Adding this `mkdir` command avoids this error for new users to the project and won't cause problems for existing users either, thanks to the `-p` flag.