### PR TITLE
Fix typos

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -39,7 +39,7 @@ independently of the database. It's also a little different, being made up of tw
 * Strong random padding for uniqueness.
 
 This means that it naturally sorts by time to the millisecond (close enough for us), giving us a
-performance advantage on queries ordered by a seperate creation datetime field (by contrast, UUIDv4 is 
+performance advantage on queries ordered by a separate creation datetime field (by contrast, UUIDv4 is 
 randomly distributed).
 
 If you've only worked with integer primary keys before, you are probably used to letting the

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -156,7 +156,7 @@ There are some useful database-related release tasks under `EctoSparkles.Migrato
 - `migrate` runs all up migrations
 - `rollback(step)` roll back to step X
 - `rollback_to(version)` roll back to a specific version
-- `rollback_all` rolls back all migrations back to zero (caution: this means loosing all data)
+- `rollback_all` rolls back all migrations back to zero (caution: this means losing all data)
 
 You can also directly call some functions in the code from the command line, for example:
 - to migrate: `docker exec bonfire_web bin/bonfire rpc 'EctoSparkles.Migrator.migrate'`

--- a/flavours/classic/config/bonfire_ui.exs
+++ b/flavours/classic/config/bonfire_ui.exs
@@ -1,6 +1,6 @@
 import Config
 
-# Please note that these are defaults meant to be overriden in Settings rather than edited here
+# Please note that these are defaults meant to be overridden in Settings rather than edited here
 config :bonfire, :ui,
   theme: [
     instance_name: "Bonfire",

--- a/flavours/classic/config/config.exs
+++ b/flavours/classic/config/config.exs
@@ -40,7 +40,7 @@ config :bonfire,
 config :bonfire, Bonfire.Web.Endpoint,
   url: [host: "localhost"],
   http: [
-    # this gets overriden in runtime.exs
+    # this gets overridden in runtime.exs
     port: String.to_integer(System.get_env("SERVER_PORT", "4000")),
     transport_options: [socket_opts: [:inet6]]
   ],

--- a/flavours/classic/config/deps.js.sh
+++ b/flavours/classic/config/deps.js.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # any extensions/deps with a package.json in their /assets directory
-# space seperated
+# space separated
 DEPS='iconify_ex bonfire_ui_common bonfire_editor_quill'
 # bonfire_editor_ck
 

--- a/flavours/cooperation/config/config.exs
+++ b/flavours/cooperation/config/config.exs
@@ -33,7 +33,7 @@ config :bonfire,
 config :bonfire, Bonfire.Web.Endpoint,
   url: [host: "localhost"],
   http: [
-    # this gets overriden in runtime.exs
+    # this gets overridden in runtime.exs
     port: String.to_integer(System.get_env("SERVER_PORT", "4000")),
     transport_options: [socket_opts: [:inet6]]
   ],

--- a/flavours/haha/config/config.exs
+++ b/flavours/haha/config/config.exs
@@ -33,7 +33,7 @@ config :bonfire,
 config :bonfire, Bonfire.Web.Endpoint,
   url: [host: "localhost"],
   http: [
-    # this gets overriden in runtime.exs
+    # this gets overridden in runtime.exs
     port: String.to_integer(System.get_env("SERVER_PORT", "4000")),
     transport_options: [socket_opts: [:inet6]]
   ],

--- a/flavours/reflow/config/config.exs
+++ b/flavours/reflow/config/config.exs
@@ -33,7 +33,7 @@ config :bonfire,
 config :bonfire, Bonfire.Web.Endpoint,
   url: [host: "localhost"],
   http: [
-    # this gets overriden in runtime.exs
+    # this gets overridden in runtime.exs
     port: String.to_integer(System.get_env("SERVER_PORT", "4000")),
     transport_options: [socket_opts: [:inet6]]
   ],

--- a/flavours/reflow/config/prod.exs
+++ b/flavours/reflow/config/prod.exs
@@ -10,7 +10,7 @@ config :bonfire, Bonfire.Web.Endpoint, cache_static_manifest: "priv/static/cache
 config :logger,
   backends: [:console, Sentry.LoggerBackend]
 
-# Do not print debug messages in production (this can be overriden by runtime env)
+# Do not print debug messages in production (this can be overridden by runtime env)
 config :logger, level: :info
 
 config :bonfire, Bonfire.Web.Endpoint, server: true

--- a/flavours/reflow/config/test.exs
+++ b/flavours/reflow/config/test.exs
@@ -28,7 +28,7 @@ config :bonfire, Bonfire.Common.Repo,
   database: db,
   slow_query_ms: 500
 
-# These defaults are overriden in runtime.exs
+# These defaults are overridden in runtime.exs
 config :bonfire, Bonfire.Web.Endpoint,
   http: [port: 4000],
   server: if(System.get_env("TEST_INSTANCE") == "yes", do: true, else: false)

--- a/justfile
+++ b/justfile
@@ -204,7 +204,7 @@ update-repo-pull:
 update-deps-bonfire:  
 	just mix-remote bonfire.deps.update
 
-# Update evey single dependency (use with caution)
+# Update every single dependency (use with caution)
 update-deps-all: deps-clean-unused pre-update-deps
 	just mix-remote "deps.update --all"
 	just js-app-deps upgrade
@@ -463,7 +463,7 @@ rel-rebuild: rel-init rel-prepare assets-prepare
 
 # Build the Docker image (NOT including changes to local forks)
 rel-build-release: rel-init rel-prepare assets-prepare 
-	@echo "Please note that the build will not include any changes in forks/ that haven't been commited and pushed, you may want to run just contrib-release first."
+	@echo "Please note that the build will not include any changes in forks/ that haven't been committed and pushed, you may want to run just contrib-release first."
 	@just rel-build "data/null" --no-cache
 
 # Build the Docker image (including changes to local forks, and using caching)

--- a/lib/mix/tasks/account/account.new.ex
+++ b/lib/mix/tasks/account/account.new.ex
@@ -1,4 +1,4 @@
-## About half of htis code is taken from hex, therefore this whole
+## About half of this code is taken from hex, therefore this whole
 ## file is considered under the same license terms as hex.
 defmodule Mix.Tasks.Bonfire.Account.New do
   use Mix.Task

--- a/lib/mix/tasks/dep.compile.ex
+++ b/lib/mix/tasks/dep.compile.ex
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.Bonfire.Dep.Compile do
   @moduledoc """
   Compiles dependencies.
 
-  This is a modified version of Elixir's `Mix.Tasks.Deps.Compile` which was needed to compile depedencies and extract localisable strings in `Mix.Tasks.Bonfire.Localise.Extract`
+  This is a modified version of Elixir's `Mix.Tasks.Deps.Compile` which was needed to compile dependencies and extract localisable strings in `Mix.Tasks.Bonfire.Localise.Extract`
 
   By default, compile all dependencies. A list of dependencies
   can be given compile multiple dependencies in order.
@@ -129,10 +129,10 @@ defmodule Mix.Tasks.Bonfire.Dep.Compile do
 
       try do
         # If "compile" was never called, the reenabling is a no-op and
-        # "compile.elixir" is a no-op as well (because it wasn't reenabled after
+        # "compile.elixir" is a no-op as well (because it wasn't re-enabled after
         # running "compile"). If "compile" was already called, then running
         # "compile" is a no-op and running "compile.elixir" will work because we
-        # manually reenabled it.
+        # manually re-enabled it.
         Mix.Task.reenable("compile.elixir")
         Mix.Task.reenable("compile.leex")
         Mix.Task.reenable("compile.all")

--- a/lib/mix/tasks/localise/localise.extract.ex
+++ b/lib/mix/tasks/localise/localise.extract.ex
@@ -91,10 +91,10 @@ defmodule Mix.Tasks.Bonfire.Localise.Extract do
     Mix.Tasks.Bonfire.Dep.Compile.run(["--force"] ++ List.wrap(deps_to_localise))
 
     # If "compile" was never called, the reenabling is a no-op and
-    # "compile.elixir" is a no-op as well (because it wasn't reenabled after
+    # "compile.elixir" is a no-op as well (because it wasn't re-enabled after
     # running "compile"). If "compile" was already called, then running
     # "compile" is a no-op and running "compile.elixir" will work because we
-    # manually reenabled it.
+    # manually re-enabled it.
     Mix.Task.reenable("compile.elixir")
     Mix.Task.run("compile")
     Mix.Task.run("compile.elixir")

--- a/lib/mix/tasks/release/lib/release.ex
+++ b/lib/mix/tasks/release/lib/release.ex
@@ -1,7 +1,7 @@
 defmodule Releaser.VersionUtils do
   @doc """
   Some utilities to get and set version numbers in the `mix.exs` file
-  and to programatically transform version numbers.
+  and to programmatically transform version numbers.
   Maybe the `bump_*` functions should be in the standard library?
   This script doesn't support pre-release versions or versions with build information.
   """

--- a/lib/mix/tasks/users/user.admin.promote.ex
+++ b/lib/mix/tasks/users/user.admin.promote.ex
@@ -1,4 +1,4 @@
-## About half of htis code is taken from hex, therefore this whole
+## About half of this code is taken from hex, therefore this whole
 ## file is considered under the same license terms as hex.
 defmodule Mix.Tasks.Bonfire.User.Admin.Promote do
   use Mix.Task


### PR DESCRIPTION
Found via `codespell -S priv,assets,CHANGELOG.md -L ro,reenable,warmup`