### PR TITLE
Add Just, Yarn and Node to tools versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,5 @@
 erlang 25.3
 elixir 1.14.3-otp-25
+just 1.13.0
+yarn 1.22.19
+nodejs 19.8.1


### PR DESCRIPTION
For users using `asdf` they should only need to do `asdf install` in the directory to have all the required deps ready to be installed. 

I'm using the latest version at the time of creation, and it should be noted that so far it hasn't been tested (I'm still waiting for `rel-build` to complete)  