### PR TITLE
Fix: Justfile OTP build assets in correct place + Docs

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -47,6 +47,9 @@ The first thing to do is choose what flavour of Bonfire (eg. classic, community,
 
 You may also want to put this in the appropriate place in your system so your choice of flavour is remembered for next time (eg. `~/.bashrc` or `~/.zshrc`)
 
+If you're not planning on using Docker, you'll also need:
+
+- `export WITH_DOCKER=no`
 
 ## Step 2- Prepare the config
 
@@ -199,11 +202,9 @@ For production, we recommend to set up a CI workflow to automate this, for an ex
 
 - Make sure you have erlang and elixir installed (check `Dockerfile` for what version we're currently using)
 
-- `export WITH_DOCKER=no` 
+- `export WITH_DOCKER=no` OR add `WITH_DOCKER=no` to the end of `.env` and source it with `source .env`
 
-- `just flavour [classic or your choice of flavour]` to select your flavour, set up some things, and download dependencies
-
-- Run `just rel-build` to create an elixir release. This will create an executable in your `_build/prod/rel/bonfire` directory. Note that you will need `just` to pass in the `.env` file to the executable, like so: `just cmd _build/prod/rel/bonfire/bin/bonfire <bonfire command>`. We will be using the `bin/bonfire` executable as called from `just` from here on. 
+- Run `just rel-build` to create an elixir release. This will create an executable in your `_build/prod/rel/bonfire` directory. Note that you will need `just` to pass in the `.env` file to the executable, like so: `just cmd _build/prod/rel/bonfire/bin/bonfire <bonfire command>`. Alternatively, this file can be sourced by `source .env` instead. We will be using the `bin/bonfire` executable as called from `just` from here on. 
 
 #### C-2. Running the release
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -394,6 +394,8 @@ The common and convenient way for adding HTTPS is by using a reverse proxy like 
 
 Caddyserver and other servers can handle generating and setting up HTTPS certificates automatically, but if you need TLS/SSL certificates for nginx, you can look get some for free with [letsencrypt](https://letsencrypt.org/). The simplest way to obtain and install a certificate is to use [Certbot.](https://certbot.eff.org). Depending on your specific setup, certbot may be able to get a certificate and configure your web server automatically.
 
+If you've built from source, you should point the nginx root directory to be `_build/prod/rel/bonfire/lib/bonfire-0.1.0-*/priv/static`
+
 ## Troubleshooting
 
 Some common issues that may arise during deployment and our suggestions for resolving them.

--- a/justfile
+++ b/justfile
@@ -535,10 +535,8 @@ rel-build USE_EXT="local" ARGS="":
 rel-build-OTP USE_EXT="local" ARGS="": rel-init rel-prepare 
 	yarn -v || npm install --global yarn
 	npm install --global esbuild postcss
-	cd ./assets && yarn build && cd ..
 	-rm -rf priv/static
-	just assets-prepare 
-	just assets-ln
+	cd ./assets && yarn build && cd ..
 	ls -la priv/static/ && ls -la priv/static/data && ls -la priv/static/data/uploads
 	just rel-mix {{ USE_EXT }} phx.digest
 	just rel-mix {{ USE_EXT }} release


### PR DESCRIPTION
Updated the justfile so that `just rel-build` with `WITH_DOCKER=no` successfully builds a release that contains the correct assets. No longer require `just flavour <flavour>` since `just config` will do that for us. It'll also configure the assets in the correct place, so I updated the docs to reflect that. 

Also included is the nginx root directory location (though it's version dependent)