### PR TITLE
Add fallback value when missing env variable

### DIFF
--- a/justfile
+++ b/justfile
@@ -52,7 +52,7 @@ CONFIG_PATH := FLAVOUR_PATH + "/config"
 UID := `id -u`
 GID := `id -g`
 
-PROXY_CADDYFILE_PATH := if env_var('PUBLIC_PORT') == "443" { "./config/deploy/Caddyfile2-https" } else { "./config/deploy/Caddyfile2" }  
+PROXY_CADDYFILE_PATH := if env_var_or_default('PUBLIC_PORT', '4000') == "443" { "./config/deploy/Caddyfile2-https" } else { "./config/deploy/Caddyfile2" }  
 
 ENV_ENV := if MIX_ENV == "test" { "dev" } else { MIX_ENV } 
 


### PR DESCRIPTION
Fix #580

For a fresh project clone and dev environment where key env variables are missing, this change avoids the crash described in #580.

**Related but not blocking:**

 However, there are still more things that crash later on (due to other details missing in the dev environment). These might be handled in separate issues and PR:s though.