### PR TITLE
fix broken just asdf version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -4,7 +4,7 @@ erlang       27.0
 elixir       1.17.0-rc.0-otp-27
 # erlang       25.3.2.8
 # elixir       1.13.4-otp-25
-just         1.27
+just         1.27.0
 yarn         1.22.19
 nodejs       21.6.1
 # chromedriver latest


### PR DESCRIPTION
`asdf install` breaks because 

```
https://github.com/casey/just/releases/download/1.27/just-1.27-x86_64-unknown-linux-musl.tar.gz
```

is not the right URL

It needs to be `1.27.0`