### PR TITLE
fix git-invalid file mode

### DIFF
--- a/justfile
+++ b/justfile
@@ -112,7 +112,7 @@ init services="db": _pre-init
 	mkdir -p priv/static/data
 	mkdir -p extensions/
 	mkdir -p forks/
-	chmod 700 .erlang.cookie
+	chmod 644 .erlang.cookie
 
 _ln-spark-deps:
 	cd config && (find ../extensions/bonfire/ -type f -name "deps.*" -exec ln -sfn {} ./ \; || find ../deps/bonfire/ -type f -name "deps.*" -exec ln -sfn {} ./ \; || echo "Could not symlink the bonfire_spark deps") && ls -la ./


### PR DESCRIPTION
https://github.com/git/git/blob/c3ebe91b40c23a1b70dba36383a23016711d8bc0/Documentation/user-manual.txt#L3052

> Note that the files all have mode 644 or 755: Git actually only pays attention to the executable bit.