### PR TITLE
Fix markdown on release canidate notice in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ![Bonfire wallpaper](https://i.imgur.com/dbRT0Z1.png)
 
-> #### Info {: .info}
+> [!NOTE]
 >
 > The release candidate of Bonfire Social 1.0 is ready! Other flavours of Bonfire are currently at alpha or beta stages. 
 


### PR DESCRIPTION
change `####info {: .info}` in README.md to `[!NOTE]`

before
<img width="1051" height="137" alt="bonfire-app-readme" src="https://github.com/user-attachments/assets/f588656c-6dd0-49a0-8975-e377fe360c47" />

after
<img width="1123" height="131" alt="bonfire-app-readme-updated" src="https://github.com/user-attachments/assets/67ce8edc-11ac-497f-8f0d-6948fb25e146" />
