### PR TITLE
moved auto conf file outside postgres data folder

### DIFF
--- a/config/deploy/postgres-entrypoint.sh
+++ b/config/deploy/postgres-entrypoint.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 [[ "$SCRIPT_DIR" == "/" ]] && SCRIPT_DIR=""
 
 # Configuration via environment variables
-POSTGRES_CONF_PATH="${POSTGRES_CONF_PATH:-/var/lib/postgresql/data/postgresql.auto.conf}"
+POSTGRES_CONF_PATH="${POSTGRES_CONF_PATH:-/var/lib/postgresql/postgresql.auto.conf}"
 POSTGRES_START_CMD="${POSTGRES_START_CMD:-docker-entrypoint.sh postgres}"
 
 # Check if envsubst is available, if not, load our bash implementation


### PR DESCRIPTION
The postgresql.auto.conf was placed in the /var/lib/postgresql/data/ folder which causes the container to stop DB initialization due to non empty data folder.
This PR moves the file in the /var/lib/postgresql/ root folder, allowing correct DB initialization 