### PR TITLE
https://github.com/bonfire-networks/bonfire-app/issues/1651

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule Bonfire.Umbrella.MixProject do
              git: "https://github.com/bonfire-networks/#{base_flavour}", override: true}
         )
       ] ++
-        if flavour != default_flavour do
+        if flavour != base_flavour do
           [
             if(flavour_local? and use_local_forks?,
               do:


### PR DESCRIPTION
This PR makes it so that `mix.exs` installs `flavour` if it is different than `base_flavour`,
`base_flavour` being the case handled just before that.
This instead of installing `flavour` if it is different than `default_flavour` which makes little sense to me here.

Possibly fix partially: #1651