### PR TITLE
replaced millisecond calculations with to_timeout() function -  issue #1729

### DIFF
--- a/config/activity_pub.exs
+++ b/config/activity_pub.exs
@@ -39,8 +39,8 @@ config :activity_pub, :http,
   user_agent: "Bonfire ActivityPub federation",
   send_user_agent: true,
   adapter: [
-    recv_timeout: 30_000,
-    connect_timeout: 10_000,
+    recv_timeout: to_timeout(second: 30),
+    connect_timeout: to_timeout(second: 10),
     ssl_options: [
       # Workaround for remote server certificate chain issues
       # partial_chain: &:hackney_connect.partial_chain/1,
@@ -110,4 +110,4 @@ config :activity_pub,
   }
 
 config :hammer,
-  backend: {Hammer.Backend.ETS, [expiry_ms: 60_000 * 60 * 4, cleanup_interval_ms: 60_000 * 10]}
+  backend: {Hammer.Backend.ETS, [expiry_ms: to_timeout(hour: 4), cleanup_interval_ms: to_timeout(minute: 10)]}

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -46,7 +46,7 @@ config :bonfire, Bonfire.Web.Endpoint,
   check_origin: false,
   http:
     if(use_cowboy?,
-      do: [protocol_options: [idle_timeout: 120_000]],
+      do: [protocol_options: [idle_timeout: to_timeout(minute: 2)]],
       else: [
         http_1_options: [max_requests: max_requests],
         http_1_options: [max_requests: max_requests]
@@ -165,7 +165,7 @@ config :phoenix, :plug_init_mode, :runtime
 
 config :exsync,
   src_monitor: true,
-  reload_timeout: 75,
+  reload_timeout: to_timeout(millisecond: 75),
   # addition_dirs: ["/forks"],
   extra_extensions: [".leex", ".heex", ".js", ".css", ".sface"]
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -149,7 +149,7 @@ config :bonfire, Bonfire.Web.Endpoint,
       else: Bandit.PhoenixAdapter
     ),
   http: http_options,
-  thousand_island: [transport_ports: [hibernate_after: 15_000]],
+  thousand_island: [transport_ports: [hibernate_after: to_timeout(second: 15)]],
   secret_key_base: secret_key_base,
   live_view: [signing_salt: signing_salt]
 
@@ -182,10 +182,10 @@ finch_pools = %{
     conn_opts: finch_conn_opts
   ],
   "https://icons.duckduckgo.com" => [
-    conn_opts: [transport_opts: [size: 8, timeout: 3_000, conn_opts: finch_conn_opts]]
+    conn_opts: [transport_opts: [size: 8, timeout: to_timeout(second: 3), conn_opts: finch_conn_opts]]
   ],
   "https://www.google.com/s2/favicons" => [
-    conn_opts: [transport_opts: [size: 8, timeout: 3_000, conn_opts: finch_conn_opts]]
+    conn_opts: [transport_opts: [size: 8, timeout: to_timeout(second: 3), conn_opts: finch_conn_opts]]
   ]
 }
 
@@ -461,7 +461,7 @@ if api_key = System.get_env("PIRATE_WEATHER_API") do
     backend: Forecastr.PirateWeather,
     appid: api_key,
     # minutes to cache
-    ttl: 14 * 60_000
+    ttl: to_timeout(minute: 14)
 end
 
 if api_key = System.get_env("OPEN_WEATHER_MAP_API_KEY") do
@@ -469,7 +469,7 @@ if api_key = System.get_env("OPEN_WEATHER_MAP_API_KEY") do
     backend: Forecastr.OWM,
     appid: api_key,
     # minutes to cache
-    ttl: 14 * 60_000
+    ttl: to_timeout(minute: 14)
 end
 
 IO.puts("Runtime config ready")

--- a/config/test.exs
+++ b/config/test.exs
@@ -108,7 +108,7 @@ chromedriver_path =
 config :wallaby,
   otp_app: :bonfire,
   # base_url: Bonfire.Web.Endpoint.url(),
-  max_wait_time: 6_000,
+  max_wait_time: to_timeout(second: 6),
   screenshot_on_failure: true,
   chromedriver: [
     # point to your chromedriver path

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -311,11 +311,11 @@ In this case, the seeds were unable to complete because a query took too long to
 
 1. Open `config/dev.exs` in your editor.
 2. Find the database configuration (search for `Bonfire.Common.Repo`).
-3. Add `timeout: 60_000` to the list of options:
+3. Add `timeout: to_timeout(minute: 1)` to the list of options:
 
 ```
 config :bonfire, Bonfire.Common.Repo,
-  timeout: 60_000,
+  timeout: to_timeout(minute: 1),
   [...]
 ```
 

--- a/lib/load_testing/load_testing.ex.old
+++ b/lib/load_testing/load_testing.ex.old
@@ -70,7 +70,7 @@ if Code.ensure_loaded?(Chaperon.Scenario) do
        remote_base_url = TestInstanceRepo.apply( ActivityPub.Federator.Adapter.base_url() )
 
       do: %{
-        # scenario_timeout: 12_000,
+        # scenario_timeout: to_timeout(second: 12),
         merge_scenario_sessions: true,
         base_url: remote_base_url,
         timeout: :infinity,


### PR DESCRIPTION
This PR replaces hard-coded millisecond timeout calculations with Elixir’s built-in `to_timeout/1` for improved readability and flexibility - proposed solution to issue #1729

