### PR TITLE
test: add strict feed pagination benchmark harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ config/current_flavour
 priv/seed_data
 assets/static/data
 priv/repo
+.bonfire-pagination-regression.lock
 
 # user-local overrides for mess
 deps.path

--- a/benchmarks/classic_feed_benchmark.exs
+++ b/benchmarks/classic_feed_benchmark.exs
@@ -1,0 +1,1219 @@
+defmodule Bonfire.ClassicFeedBenchmark do
+  @moduledoc false
+
+  alias Bonfire.Boundaries.Acls
+  alias Bonfire.Common.Config
+  alias Bonfire.Common.Repo
+  alias Bonfire.Social.FeedActivities
+  alias Bonfire.Social.Feeds
+
+  @remote_feed "00000000-0000-4000-8000-ffffffffffff"
+  @fetcher_subject "1ACT1V1TYPVBREM0TESFETCHER"
+
+  @synthetic_min "00000000-0000-4000-8000-000000000000"
+  @synthetic_max "00000000-0000-4000-8000-ffffffffffff"
+  @churn_min "00000000-0000-4000-9000-000000000000"
+  @churn_max "00000000-0000-4000-9000-ffffffffffff"
+
+  def run do
+    ensure_test_database_target!()
+    start_application!()
+
+    rows = env_int("BONFIRE_CLASSIC_FEED_ROWS", 50_000)
+    iterations = env_int("BONFIRE_CLASSIC_BENCH_ITERATIONS", 7)
+    limit = env_int("BONFIRE_CLASSIC_BENCH_LIMIT", 20)
+    remote_every = env_int("BONFIRE_CLASSIC_REMOTE_EVERY", 10)
+    fetcher_every = env_int("BONFIRE_CLASSIC_FETCHER_EVERY", 50)
+    local_every = env_optional_int("BONFIRE_CLASSIC_LOCAL_EVERY")
+    hidden_local_every = env_optional_int("BONFIRE_CLASSIC_HIDDEN_LOCAL_EVERY")
+    hidden_local_burst_rows = env_int("BONFIRE_CLASSIC_HIDDEN_LOCAL_BURST_ROWS", 0)
+    churn_rows = env_int("BONFIRE_CLASSIC_CHURN_ROWS", 0)
+    keep_rows? = System.get_env("BONFIRE_CLASSIC_KEEP_ROWS") == "1"
+    vacuum_after_churn? = System.get_env("BONFIRE_CLASSIC_VACUUM_AFTER_CHURN") == "1"
+    vacuum_after_seed? = System.get_env("BONFIRE_CLASSIC_VACUUM_AFTER_SEED") == "1"
+    warmup_runs = env_int("BONFIRE_CLASSIC_BENCH_WARMUP_RUNS", 0)
+
+    ensure_test_database!()
+    pagination_hard_max_limit = configure_feed_target(limit)
+    configure_session()
+
+    ids = static_ids()
+    table_id = table_id!("bonfire_data_social_post")
+    verb_id = verb_id!("Create")
+
+    try do
+      cleanup_churn_rows()
+      cleanup_synthetic_rows()
+      cleanup_benchmark_static_rows(ids, table_id)
+      ensure_static_pointers(ids, table_id)
+
+      seed_and_delete_churn_rows(churn_rows, table_id, verb_id, ids)
+      if vacuum_after_churn?, do: vacuum_feed_tables()
+
+      seed_classic_like_rows(
+        rows,
+        remote_every,
+        fetcher_every,
+        local_every,
+        hidden_local_every,
+        hidden_local_burst_rows,
+        table_id,
+        verb_id,
+        ids
+      )
+
+      if vacuum_after_seed?, do: vacuum_feed_tables("after_seed")
+      seed_integrity = validate_seed_integrity!(ids, rows)
+      unless vacuum_after_seed?, do: analyze_feed_tables()
+
+      index_info = index_info()
+      counts = counts(ids)
+      relation_sizes = relation_sizes()
+      {cold_first_timing, warmup_timings, first_timing} = warmup_then_time(warmup_runs, limit)
+      page_walk = page_walk(limit)
+      explain = explain(limit, explain_after_cursor(page_walk))
+      plan_flags = plan_flags(explain)
+      explain_json = explain_json(limit, explain_after_cursor(page_walk))
+      plan_metrics = plan_metrics(explain_json)
+      timings = timings(iterations, limit)
+      requirements = requirements(limit)
+
+      report = %{
+        counts: counts,
+        churn_rows: churn_rows,
+        explain: explain,
+        fetcher_every: fetcher_every,
+        cold_first_timing: cold_first_timing,
+        first_timing: first_timing,
+        fast_seed?: fast_seed?(),
+        hidden_local_every: hidden_local_every,
+        hidden_local_burst_rows: hidden_local_burst_rows,
+        index_info: index_info,
+        iterations: iterations,
+        keep_rows?: keep_rows?,
+        limit: limit,
+        local_every: local_every,
+        page_walk: page_walk,
+        pagination_hard_max_limit: pagination_hard_max_limit,
+        plan_flags: plan_flags,
+        plan_metrics: plan_metrics,
+        remote_every: remote_every,
+        requirements: requirements,
+        relation_sizes: relation_sizes,
+        rows: rows,
+        seed_integrity: seed_integrity,
+        timings: timings,
+        vacuum_after_churn?: vacuum_after_churn?,
+        vacuum_after_seed?: vacuum_after_seed?,
+        warmup_runs: warmup_runs,
+        warmup_timings: warmup_timings
+      }
+
+      print_report(report)
+      enforce_requirements!(report)
+    after
+      unless keep_rows? do
+        cleanup_churn_rows()
+        cleanup_synthetic_rows()
+        cleanup_benchmark_static_rows(ids, table_id)
+        IO.puts("cleanup=synthetic_rows_removed")
+      end
+    end
+  end
+
+  defp start_application! do
+    Enum.each([:ecto, :db_connection, :postgrex, :ecto_sql, :phoenix_pubsub], &ensure_started!/1)
+    ensure_pubsub_started()
+
+    Mix.Task.run("ecto.create")
+    start_repo!()
+
+    if System.get_env("BONFIRE_LIGHTWEIGHT_TEST_MIGRATE") == "1" do
+      Mix.Task.run("ecto.migrate")
+      run_extension_migrations_strict!()
+    end
+  end
+
+  defp run_extension_migrations_strict! do
+    results = EctoSparkles.Migrator.migrate_repo(Repo, continue_on_error: true)
+    failures = Enum.reject(results, &match?({:ok, _version, _desc}, &1))
+
+    case failures do
+      [] -> :ok
+      failures -> raise "Extension migrations failed: #{inspect(failures)}"
+    end
+  end
+
+  defp ensure_started!(app) do
+    case Application.ensure_all_started(app) do
+      {:ok, _apps} ->
+        :ok
+
+      {:error, reason} ->
+        raise "Could not start #{inspect(app)} for benchmark: #{inspect(reason)}"
+    end
+  end
+
+  defp ensure_pubsub_started do
+    unless Process.whereis(Bonfire.Common.PubSub) do
+      Supervisor.start_link(
+        [{Phoenix.PubSub, name: Bonfire.Common.PubSub}],
+        strategy: :one_for_one
+      )
+    end
+  end
+
+  defp start_repo! do
+    case Repo.start_link() do
+      {:ok, _pid} ->
+        :ok
+
+      {:error, {:already_started, _pid}} ->
+        :ok
+
+      {:error, reason} ->
+        raise "Could not start #{inspect(Repo)} for benchmark: #{inspect(reason)}"
+    end
+  end
+
+  defp configure_feed_target(limit) do
+    Config.put([Bonfire.Social.Feeds, :query_with_deferred_join], true)
+    Config.put([Bonfire.UI.Social.FeedLive, :time_limit], 0)
+
+    hard_max =
+      env_int("BONFIRE_CLASSIC_BENCH_HARD_MAX_LIMIT", max(limit * 32 + 1, 500))
+      |> max(limit)
+
+    Config.put(:pagination_hard_max_limit, hard_max)
+    hard_max
+  end
+
+  defp configure_session do
+    set_if_present("BONFIRE_CLASSIC_BENCH_WORK_MEM", "work_mem")
+    set_if_present("BONFIRE_CLASSIC_BENCH_EFFECTIVE_CACHE_SIZE", "effective_cache_size")
+    set_if_present("BONFIRE_CLASSIC_BENCH_RANDOM_PAGE_COST", "random_page_cost")
+  end
+
+  defp set_if_present(env, setting) do
+    case System.get_env(env) do
+      nil -> :ok
+      "" -> :ok
+      value -> Repo.query!("SET #{setting} = '#{String.replace(value, "'", "''")}'")
+    end
+  end
+
+  defp ensure_test_database! do
+    %{rows: [[database]]} = Repo.query!("select current_database()")
+
+    unless test_database_name?(database) or
+             System.get_env("BONFIRE_CLASSIC_BENCH_ALLOW_NON_TEST") == "1" do
+      raise """
+      Refusing to seed benchmark rows into #{database}.
+      Use a test DATABASE_URL or set BONFIRE_CLASSIC_BENCH_ALLOW_NON_TEST=1 intentionally.
+      """
+    end
+  end
+
+  defp ensure_test_database_target! do
+    database =
+      database_from_url(System.get_env("DATABASE_URL")) ||
+        System.get_env("POSTGRES_DB") ||
+        database_from_loaded_config()
+
+    if database &&
+         not test_database_name?(database) &&
+         System.get_env("BONFIRE_CLASSIC_BENCH_ALLOW_NON_TEST") != "1" do
+      raise """
+      Refusing to create, migrate, or seed benchmark rows into #{database}.
+      Use a test DATABASE_URL or set BONFIRE_CLASSIC_BENCH_ALLOW_NON_TEST=1 intentionally.
+      """
+    end
+  end
+
+  defp database_from_url(nil), do: nil
+  defp database_from_url(""), do: nil
+
+  defp database_from_url(url) do
+    case URI.parse(url).path do
+      "/" <> database when database != "" -> URI.decode(database)
+      _ -> nil
+    end
+  end
+
+  defp database_from_loaded_config do
+    Application.get_env(:bonfire, Repo, [])[:database] ||
+      Application.get_env(:bonfire_common, Repo, [])[:database]
+  end
+
+  defp test_database_name?(database) when is_binary(database),
+    do: String.contains?(database, "_test")
+
+  defp test_database_name?(_), do: false
+
+  defp static_ids do
+    %{
+      fetcher_subject: db_uid!(@fetcher_subject),
+      hidden_acl: named_acl_uid!(:locals_may_see),
+      local_feed: named_feed_uid!(:local),
+      visible_acl:
+        named_acl_uid!(env_existing_atom("BONFIRE_CLASSIC_VISIBLE_ACL", :everyone_may_see_read)),
+      remote_feed: db_uid!(@remote_feed)
+    }
+  end
+
+  defp named_feed_uid!(name) do
+    case Feeds.named_feed_id(name) do
+      id when is_binary(id) ->
+        db_uid!(id)
+
+      other ->
+        raise "Expected #{inspect(name)} to have a persisted feed id, got #{inspect(other)}"
+    end
+  end
+
+  defp named_acl_uid!(name) do
+    case Acls.get_id(name) do
+      id when is_binary(id) ->
+        db_uid!(id)
+
+      other ->
+        raise "Expected #{inspect(name)} to have a persisted ACL id, got #{inspect(other)}"
+    end
+  end
+
+  defp env_existing_atom(env, default) do
+    case System.get_env(env) do
+      nil ->
+        default
+
+      "" ->
+        default
+
+      value ->
+        try do
+          String.to_existing_atom(value)
+        rescue
+          ArgumentError -> raise "Unknown #{env}=#{inspect(value)}"
+        end
+    end
+  end
+
+  defp db_uid!(encoded) do
+    case Ecto.UUID.dump(encoded) do
+      {:ok, uid} ->
+        uid
+
+      :error ->
+        case Needle.UID.dump(encoded) do
+          {:ok, uid} -> uid
+          _ -> encoded |> Needle.UID.synthesise!() |> Needle.UID.dump!()
+        end
+    end
+  end
+
+  defp table_id!(table) do
+    %{rows: [[id]]} =
+      Repo.query!("select id from pointers_table where \"table\" = $1", [table])
+
+    id
+  end
+
+  defp verb_id!(verb) do
+    %{rows: [[id]]} =
+      Repo.query!("select id from bonfire_data_access_control_verb where verb = $1", [verb])
+
+    id
+  end
+
+  defp cleanup_synthetic_rows do
+    cleanup_rows_in_range(@synthetic_min, @synthetic_max)
+  end
+
+  defp cleanup_churn_rows do
+    cleanup_rows_in_range(@churn_min, @churn_max)
+  end
+
+  defp cleanup_rows_in_range(min_id, max_id) do
+    id_range = [Ecto.UUID.dump!(min_id), Ecto.UUID.dump!(max_id)]
+    batch_size = env_int("BONFIRE_CLASSIC_CLEANUP_BATCH", 25_000)
+
+    Enum.each(
+      [
+        "bonfire_data_social_feed_publish",
+        "bonfire_data_access_control_controlled",
+        "bonfire_data_social_activity",
+        "pointers_pointer"
+      ],
+      &delete_rows_in_range(&1, id_range, batch_size)
+    )
+  end
+
+  defp delete_rows_in_range(table, id_range, batch_size) do
+    %{num_rows: rows} =
+      Repo.query!(
+        """
+        with doomed as (
+          select id
+          from #{table}
+          where id >= $1::uuid and id <= $2::uuid
+          limit $3
+        )
+        delete from #{table} target
+        using doomed
+        where target.id = doomed.id
+        """,
+        id_range ++ [batch_size],
+        timeout: :infinity
+      )
+
+    if rows == batch_size do
+      delete_rows_in_range(table, id_range, batch_size)
+    end
+  end
+
+  defp cleanup_benchmark_static_rows(ids, table_id) do
+    Repo.query!(
+      """
+      delete from pointers_pointer pointer
+      where pointer.id = $1::uuid
+        and pointer.table_id = $2::uuid
+        and not exists (
+          select 1
+          from bonfire_data_social_activity activity
+          where activity.id = pointer.id
+             or activity.subject_id = pointer.id
+             or activity.object_id = pointer.id
+        )
+        and not exists (
+          select 1
+          from bonfire_data_social_feed_publish feed_publish
+          where feed_publish.id = pointer.id
+             or feed_publish.feed_id = pointer.id
+        )
+      """,
+      [ids.fetcher_subject, table_id],
+      timeout: :infinity
+    )
+  end
+
+  defp ensure_static_pointers(ids, table_id) do
+    ensure_pointer_exists!(ids.local_feed, "local feed")
+
+    Repo.query!(
+      """
+      insert into pointers_pointer (id, table_id)
+      values ($1, $3), ($2, $3)
+      on conflict (id) do nothing
+      """,
+      [ids.remote_feed, ids.fetcher_subject, table_id]
+    )
+  end
+
+  defp ensure_pointer_exists!(id, label) do
+    %{num_rows: rows} =
+      Repo.query!("select 1 from pointers_pointer where id = $1::uuid limit 1", [id])
+
+    if rows != 1, do: raise("Expected #{label} pointer to exist before benchmark")
+  end
+
+  defp seed_classic_like_rows(
+         rows,
+         remote_every,
+         fetcher_every,
+         local_every,
+         hidden_local_every,
+         hidden_local_burst_rows,
+         table_id,
+         verb_id,
+         ids
+       ) do
+    seed_batch_size = env_int("BONFIRE_CLASSIC_SEED_BATCH", 25_000)
+
+    each_batch("main", rows, seed_batch_size, fn offset, batch_rows ->
+      with_seed_acceleration(fn ->
+        seed_classic_like_row_batch(
+          offset,
+          batch_rows,
+          rows,
+          remote_every,
+          fetcher_every,
+          local_every,
+          hidden_local_every,
+          hidden_local_burst_rows,
+          table_id,
+          verb_id,
+          ids
+        )
+      end)
+    end)
+  end
+
+  defp seed_classic_like_row_batch(
+         offset,
+         rows,
+         total_rows,
+         remote_every,
+         fetcher_every,
+         local_every,
+         hidden_local_every,
+         hidden_local_burst_rows,
+         table_id,
+         verb_id,
+         ids
+       ) do
+    Repo.query!(
+      """
+      with generated as (
+        select
+          ('00000000-0000-4000-8000-' || lpad(to_hex(gs), 12, '0'))::uuid as id,
+          case
+            when $14 > 0 and gs > $15 - $14 then $5::uuid
+            when $10 > 0 and gs % $10 = 0 then $5::uuid
+            when $12 > 0 and gs % $12 = 0 then $5::uuid
+            when $10 > 0 then $6::uuid
+            when $3 > 0 and gs % $3 = 0 then $6::uuid
+            else $5::uuid
+          end as feed_id,
+          case when $4 > 0 and gs % $4 = 0 then $7::uuid else $5::uuid end as subject_id,
+          case
+            when $14 > 0 and gs > $15 - $14 then $13::uuid
+            when $10 > 0 and gs % $10 = 0 then $11::uuid
+            when $12 > 0 and gs % $12 = 0 then $13::uuid
+            else $11::uuid
+          end as acl_id
+        from generate_series($1 + 1, $1 + $2) as gs
+      ),
+      pointer_insert as (
+        insert into pointers_pointer (id, table_id)
+        select id, $8::uuid from generated
+        on conflict (id) do nothing
+      ),
+      activity_insert as (
+        insert into bonfire_data_social_activity (id, subject_id, object_id, verb_id)
+        select id, subject_id, id, $9::uuid from generated
+        on conflict (id) do nothing
+      ),
+      controlled_insert as (
+        insert into bonfire_data_access_control_controlled (id, acl_id)
+        select id, acl_id from generated
+        on conflict (id, acl_id) do nothing
+      )
+      insert into bonfire_data_social_feed_publish (id, feed_id)
+      select id, feed_id from generated
+      on conflict (id, feed_id) do nothing
+      """,
+      [
+        offset,
+        rows,
+        remote_every,
+        fetcher_every,
+        ids.local_feed,
+        ids.remote_feed,
+        ids.fetcher_subject,
+        table_id,
+        verb_id,
+        local_every || 0,
+        ids.visible_acl,
+        hidden_local_every || 0,
+        ids.hidden_acl,
+        hidden_local_burst_rows,
+        total_rows
+      ],
+      timeout: :infinity
+    )
+  end
+
+  defp seed_and_delete_churn_rows(0, _table_id, _verb_id, _ids), do: :ok
+
+  defp seed_and_delete_churn_rows(rows, table_id, verb_id, ids) do
+    seed_batch_size = env_int("BONFIRE_CLASSIC_SEED_BATCH", 25_000)
+
+    each_batch("churn", rows, seed_batch_size, fn offset, batch_rows ->
+      with_seed_acceleration(fn ->
+        Repo.query!(
+          """
+          with generated as (
+            select
+              ('00000000-0000-4000-9000-' || lpad(to_hex(gs), 12, '0'))::uuid as id
+            from generate_series($1 + 1, $1 + $2) as gs
+          ),
+          pointer_insert as (
+            insert into pointers_pointer (id, table_id)
+            select id, $3::uuid from generated
+            on conflict (id) do nothing
+          ),
+          activity_insert as (
+            insert into bonfire_data_social_activity (id, subject_id, object_id, verb_id)
+            select id, $4::uuid, id, $5::uuid from generated
+            on conflict (id) do nothing
+          ),
+          controlled_insert as (
+            insert into bonfire_data_access_control_controlled (id, acl_id)
+            select id, $6::uuid from generated
+            on conflict (id, acl_id) do nothing
+          )
+          insert into bonfire_data_social_feed_publish (id, feed_id)
+          select id, $7::uuid from generated
+          on conflict (id, feed_id) do nothing
+          """,
+          [
+            offset,
+            batch_rows,
+            table_id,
+            ids.local_feed,
+            verb_id,
+            ids.visible_acl,
+            ids.local_feed
+          ],
+          timeout: :infinity
+        )
+      end)
+    end)
+
+    cleanup_churn_rows()
+  end
+
+  defp each_batch(label, rows, batch_size, fun) when rows > 0 do
+    0
+    |> Stream.iterate(&(&1 + batch_size))
+    |> Enum.take_while(&(&1 < rows))
+    |> Enum.each(fn offset ->
+      batch_rows = min(batch_size, rows - offset)
+      IO.puts("seed_batch=#{label}:#{offset + 1}-#{offset + batch_rows}/#{rows}")
+      fun.(offset, batch_rows)
+    end)
+  end
+
+  defp with_seed_acceleration(fun) do
+    if fast_seed?() do
+      case Repo.transaction(
+             fn ->
+               Repo.query!("SET LOCAL session_replication_role = replica")
+               fun.()
+             end,
+             timeout: :infinity
+           ) do
+        {:ok, result} -> result
+        {:error, reason} -> raise "Fast seed transaction failed: #{inspect(reason)}"
+      end
+    else
+      fun.()
+    end
+  end
+
+  defp fast_seed?, do: System.get_env("BONFIRE_CLASSIC_FAST_SEED") == "1"
+
+  defp analyze_feed_tables do
+    Repo.query!("analyze pointers_pointer")
+    Repo.query!("analyze bonfire_data_access_control_controlled")
+    Repo.query!("analyze bonfire_data_social_activity")
+    Repo.query!("analyze bonfire_data_social_feed_publish")
+  end
+
+  defp vacuum_feed_tables(label \\ "after_churn") do
+    IO.puts("vacuum_#{label}=begin")
+    Repo.query!("vacuum (analyze) pointers_pointer", [], timeout: :infinity)
+    Repo.query!("vacuum (analyze) bonfire_data_access_control_controlled", [], timeout: :infinity)
+    Repo.query!("vacuum (analyze) bonfire_data_social_activity", [], timeout: :infinity)
+    Repo.query!("vacuum (analyze) bonfire_data_social_feed_publish", [], timeout: :infinity)
+    IO.puts("vacuum_#{label}=done")
+  end
+
+  defp index_info do
+    Repo.query!("""
+    select indexname, indexdef
+    from pg_indexes
+    where tablename = 'bonfire_data_social_feed_publish'
+      and indexname like '%feed_id%'
+    order by indexname
+    """).rows
+  end
+
+  defp relation_sizes do
+    Repo.query!("""
+    select
+      relname,
+      pg_size_pretty(pg_relation_size(oid)) as table_size,
+      pg_size_pretty(pg_indexes_size(oid)) as indexes_size,
+      pg_size_pretty(pg_total_relation_size(oid)) as total_size
+    from pg_class
+    where relname in (
+      'bonfire_data_social_feed_publish',
+      'bonfire_data_social_activity',
+      'bonfire_data_access_control_controlled',
+      'pointers_pointer'
+    )
+    order by relname
+    """).rows
+  end
+
+  defp validate_seed_integrity!(ids, expected_rows) do
+    synthetic_range = [Ecto.UUID.dump!(@synthetic_min), Ecto.UUID.dump!(@synthetic_max)]
+
+    IO.puts("seed_integrity_check=feed_publish")
+    feed_publish_rows = count_range_rows("bonfire_data_social_feed_publish", synthetic_range)
+
+    IO.puts("seed_integrity_check=pointers_pointer")
+
+    pointer_rows =
+      count_range_rows("pointers_pointer", synthetic_range, exclude_id: ids.remote_feed)
+
+    IO.puts("seed_integrity_check=bonfire_data_social_activity")
+    activity_rows = count_range_rows("bonfire_data_social_activity", synthetic_range)
+
+    IO.puts("seed_integrity_check=bonfire_data_access_control_controlled")
+    controlled_rows = count_range_rows("bonfire_data_access_control_controlled", synthetic_range)
+
+    integrity = [
+      feed_publish_rows - expected_rows,
+      feed_publish_rows - pointer_rows,
+      feed_publish_rows - activity_rows,
+      feed_publish_rows - controlled_rows
+    ]
+
+    if Enum.any?(integrity, &(&1 != 0)) do
+      raise "Synthetic seed integrity failed: #{inspect(integrity)}"
+    end
+
+    integrity
+  end
+
+  defp count_range_rows(table, id_range, opts \\ []) do
+    exclude_id = Keyword.get(opts, :exclude_id)
+    exclude_filter = if exclude_id, do: "and id <> $3::uuid", else: ""
+    params = if exclude_id, do: id_range ++ [exclude_id], else: id_range
+
+    %{rows: [[rows]]} =
+      Repo.query!(
+        """
+        select count(*)
+        from #{table}
+        where id >= $1::uuid and id <= $2::uuid
+          #{exclude_filter}
+        """,
+        params,
+        timeout: :infinity
+      )
+
+    rows
+  end
+
+  defp counts(ids) do
+    synthetic_range = [Ecto.UUID.dump!(@synthetic_min), Ecto.UUID.dump!(@synthetic_max)]
+
+    %{rows: rows} =
+      Repo.query!(
+        """
+        select
+          count(*) filter (where fp.feed_id = $1::uuid) as local_rows,
+          count(*) filter (where fp.feed_id = $2::uuid) as remote_rows,
+          count(*) filter (
+            where fp.feed_id = $1::uuid and controlled.acl_id <> $6::uuid
+          ) as hidden_local_rows,
+          count(*) filter (
+            where fp.feed_id = $1::uuid
+              and controlled.acl_id = $6::uuid
+              and activity.subject_id = $5::uuid
+          ) as local_fetcher_rows,
+          count(*) filter (
+            where fp.feed_id = $1::uuid
+              and controlled.acl_id = $6::uuid
+              and activity.subject_id <> $5::uuid
+          ) as visible_local_rows,
+          count(*) as feed_publish_rows
+        from bonfire_data_social_feed_publish fp
+        join bonfire_data_social_activity activity on activity.id = fp.id
+        join bonfire_data_access_control_controlled controlled on controlled.id = fp.id
+        where fp.id >= $3::uuid and fp.id <= $4::uuid
+        """,
+        [ids.local_feed, ids.remote_feed] ++
+          synthetic_range ++ [ids.fetcher_subject, ids.visible_acl],
+        timeout: :infinity
+      )
+
+    rows
+  end
+
+  defp explain(limit, after_cursor) do
+    query =
+      :local
+      |> FeedActivities.feed(feed_opts(limit, after_cursor) ++ [return: :query])
+
+    {sql, params} = Ecto.Adapters.SQL.to_sql(:all, Repo, query)
+
+    Repo.query!(
+      "EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT) " <> sql,
+      params,
+      timeout: :infinity
+    ).rows
+    |> Enum.map_join("\n", fn [line] -> line end)
+  end
+
+  defp explain_json(limit, after_cursor) do
+    query =
+      :local
+      |> FeedActivities.feed(feed_opts(limit, after_cursor) ++ [return: :query])
+
+    {sql, params} = Ecto.Adapters.SQL.to_sql(:all, Repo, query)
+
+    Repo.query!(
+      "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) " <> sql,
+      params,
+      timeout: :infinity
+    ).rows
+    |> decode_explain_json()
+  end
+
+  defp decode_explain_json([[[plan]]]), do: decode_explain_json_value(plan)
+  defp decode_explain_json([[plan]]), do: decode_explain_json_value(plan)
+
+  defp decode_explain_json_value([plan | _]) when is_map(plan), do: plan
+
+  defp decode_explain_json_value(plan) when is_map(plan), do: plan
+
+  defp decode_explain_json_value(json) when is_binary(json) do
+    json
+    |> Jason.decode!()
+    |> List.first()
+  end
+
+  defp plan_flags(explain) do
+    %{
+      feed_publish_target_index_used:
+        String.contains?(explain, "bonfire_data_social_feed_publish_feed_id_id_idx"),
+      feed_publish_pkey_used: String.contains?(explain, "bonfire_data_social_feed_publish_pkey"),
+      feed_publish_seq_scan_used:
+        String.contains?(explain, "Seq Scan on bonfire_data_social_feed_publish")
+    }
+  end
+
+  defp plan_metrics(explain_json) do
+    nodes =
+      explain_json
+      |> Map.get("Plan")
+      |> plan_nodes()
+
+    feed_nodes =
+      Enum.filter(nodes, &(Map.get(&1, "Relation Name") == "bonfire_data_social_feed_publish"))
+
+    feed_publish_nodes =
+      Enum.map(feed_nodes, fn node ->
+        %{
+          actual_loops: number_field(node, "Actual Loops"),
+          actual_rows: number_field(node, "Actual Rows"),
+          heap_fetches: integer_field(node, "Heap Fetches"),
+          index_name: Map.get(node, "Index Name"),
+          node_type: Map.get(node, "Node Type"),
+          rows_removed_by_filter: integer_field(node, "Rows Removed by Filter"),
+          shared_hit_blocks: integer_field(node, "Shared Hit Blocks"),
+          shared_read_blocks: integer_field(node, "Shared Read Blocks"),
+          temp_read_blocks: integer_field(node, "Temp Read Blocks"),
+          temp_written_blocks: integer_field(node, "Temp Written Blocks")
+        }
+      end)
+
+    %{
+      feed_publish_actual_rows:
+        Enum.reduce(feed_publish_nodes, 0.0, fn node, total ->
+          total + node.actual_rows * max(node.actual_loops, 1.0)
+        end),
+      feed_publish_heap_fetches: sum_plan_metric(feed_publish_nodes, :heap_fetches),
+      feed_publish_nodes: feed_publish_nodes,
+      feed_publish_rows_removed_by_filter:
+        sum_plan_metric(feed_publish_nodes, :rows_removed_by_filter),
+      feed_publish_shared_read_blocks: sum_plan_metric(feed_publish_nodes, :shared_read_blocks),
+      feed_publish_temp_blocks:
+        sum_plan_metric(feed_publish_nodes, :temp_read_blocks) +
+          sum_plan_metric(feed_publish_nodes, :temp_written_blocks),
+      plan_seq_scan_nodes:
+        nodes
+        |> Enum.filter(&(Map.get(&1, "Node Type") == "Seq Scan"))
+        |> Enum.map(&Map.get(&1, "Relation Name")),
+      plan_temp_blocks:
+        Enum.reduce(nodes, 0, fn node, total ->
+          total + integer_field(node, "Temp Read Blocks") +
+            integer_field(node, "Temp Written Blocks")
+        end)
+    }
+  end
+
+  defp plan_nodes(nil), do: []
+
+  defp plan_nodes(node) when is_map(node) do
+    [node | Enum.flat_map(Map.get(node, "Plans", []), &plan_nodes/1)]
+  end
+
+  defp sum_plan_metric(nodes, key), do: Enum.reduce(nodes, 0, &(&2 + Map.fetch!(&1, key)))
+
+  defp integer_field(node, key), do: round(number_field(node, key))
+
+  defp number_field(node, key) do
+    case Map.get(node, key) do
+      nil -> 0.0
+      value when is_integer(value) -> value * 1.0
+      value when is_float(value) -> value
+    end
+  end
+
+  defp requirements(limit) do
+    %{
+      explain_page: env_int("BONFIRE_CLASSIC_EXPLAIN_PAGE", 1),
+      exact_feed_publish_rows: env_optional_int("BONFIRE_CLASSIC_EXACT_FEED_PUBLISH_ROWS"),
+      limit: limit,
+      max_feed_publish_actual_rows:
+        env_optional_float("BONFIRE_CLASSIC_MAX_FEED_PUBLISH_ACTUAL_ROWS"),
+      max_feed_publish_heap_fetches:
+        env_optional_int("BONFIRE_CLASSIC_MAX_FEED_PUBLISH_HEAP_FETCHES"),
+      max_feed_publish_rows_removed_by_filter:
+        env_optional_int("BONFIRE_CLASSIC_MAX_FEED_PUBLISH_ROWS_REMOVED_BY_FILTER"),
+      max_cold_first_ms: env_optional_float("BONFIRE_CLASSIC_MAX_COLD_FIRST_MS"),
+      max_first_ms: env_optional_float("BONFIRE_CLASSIC_MAX_FIRST_MS"),
+      max_page_ms: env_optional_float("BONFIRE_CLASSIC_MAX_PAGE_MS"),
+      max_page_p95_ms: env_optional_float("BONFIRE_CLASSIC_MAX_PAGE_P95_MS"),
+      max_p95_ms: env_optional_float("BONFIRE_CLASSIC_MAX_P95_MS"),
+      min_hidden_local_rows: env_optional_int("BONFIRE_CLASSIC_MIN_HIDDEN_LOCAL_ROWS"),
+      min_visible_local_rows: env_optional_int("BONFIRE_CLASSIC_MIN_VISIBLE_LOCAL_ROWS"),
+      page_count: env_int("BONFIRE_CLASSIC_REQUIRED_PAGES", 1),
+      require_full_page?: System.get_env("BONFIRE_CLASSIC_REQUIRE_FULL_PAGE") == "1",
+      require_no_feed_publish_seq_scan?:
+        System.get_env("BONFIRE_CLASSIC_REQUIRE_NO_FEED_PUBLISH_SEQ_SCAN") == "1",
+      require_no_temp_blocks?: System.get_env("BONFIRE_CLASSIC_REQUIRE_NO_TEMP_BLOCKS") == "1",
+      require_target_index?: System.get_env("BONFIRE_CLASSIC_REQUIRE_TARGET_INDEX") == "1"
+    }
+  end
+
+  defp timing(limit) do
+    {timing_ms, result} = timed_feed(limit, nil)
+    {timing_ms, edge_count(result)}
+  end
+
+  defp warmup_then_time(0, limit), do: {nil, [], timing(limit)}
+
+  defp warmup_then_time(warmup_runs, limit) when warmup_runs > 0 do
+    cold_first_timing = timing(limit)
+
+    warmup_timings =
+      if warmup_runs > 1, do: for(_ <- 1..(warmup_runs - 1), do: timing(limit)), else: []
+
+    {cold_first_timing, warmup_timings, timing(limit)}
+  end
+
+  defp timed_feed(limit, after_cursor) do
+    {micros, result} =
+      :timer.tc(fn ->
+        FeedActivities.feed(:local, feed_opts(limit, after_cursor))
+      end)
+
+    {micros / 1000, result}
+  end
+
+  defp feed_opts(limit, nil), do: [limit: limit, preload: false, timeout: :infinity]
+
+  defp feed_opts(limit, after_cursor),
+    do: [limit: limit, preload: false, after: after_cursor, timeout: :infinity]
+
+  defp page_walk(limit) do
+    page_count = env_int("BONFIRE_CLASSIC_REQUIRED_PAGES", 1)
+
+    {pages, _cursor, _seen_ids} =
+      Enum.reduce(1..page_count, {[], nil, MapSet.new()}, fn page, {pages, cursor, seen_ids} ->
+        {timing_ms, result} = timed_feed(limit, cursor)
+        ids = edge_ids(result)
+        duplicate_ids = ids |> MapSet.new() |> MapSet.intersection(seen_ids) |> MapSet.to_list()
+
+        page_result = %{
+          after_cursor: cursor,
+          duplicate_count: length(duplicate_ids),
+          edge_count: length(ids),
+          end_cursor: end_cursor(result),
+          page: page,
+          timing_ms: timing_ms
+        }
+
+        {[page_result | pages], page_result.end_cursor, MapSet.union(seen_ids, MapSet.new(ids))}
+      end)
+
+    Enum.reverse(pages)
+  end
+
+  defp timings(iterations, limit) do
+    for _ <- 1..iterations do
+      timing(limit)
+    end
+  end
+
+  defp explain_after_cursor(page_walk) do
+    explain_page = env_int("BONFIRE_CLASSIC_EXPLAIN_PAGE", 1)
+
+    page_walk
+    |> Enum.find(&(&1.page == explain_page))
+    |> case do
+      nil -> nil
+      page -> page.after_cursor
+    end
+  end
+
+  defp edge_count(%{edges: edges}) when is_list(edges), do: length(edges)
+  defp edge_count(rows) when is_list(rows), do: length(rows)
+  defp edge_count(_), do: 0
+
+  defp edge_ids(%{edges: edges}) when is_list(edges), do: Enum.map(edges, &edge_id/1)
+  defp edge_ids(rows) when is_list(rows), do: Enum.map(rows, &edge_id/1)
+  defp edge_ids(_), do: []
+
+  defp edge_id(%{activity: %{id: id}}), do: id
+  defp edge_id(%{id: id}), do: id
+  defp edge_id(other), do: inspect(other)
+
+  defp end_cursor(%{page_info: %{end_cursor: cursor}}), do: cursor
+  defp end_cursor(_), do: nil
+
+  defp print_report(data) do
+    timings = Enum.map(data.timings, &elem(&1, 0))
+    edge_counts = Enum.map(data.timings, &elem(&1, 1))
+    {first_timing, first_edge_count} = data.first_timing
+    page_timings = Enum.map(data.page_walk, & &1.timing_ms)
+
+    IO.puts("Classic-like local feed benchmark")
+    IO.puts("benchmark_scope=query_only_preload_false")
+    IO.puts("rows=#{data.rows}")
+    IO.puts("churn_rows=#{data.churn_rows}")
+    IO.puts("remote_every=#{data.remote_every}")
+    IO.puts("fetcher_every=#{data.fetcher_every}")
+    IO.puts("local_every=#{data.local_every || "disabled"}")
+    IO.puts("hidden_local_every=#{data.hidden_local_every || "disabled"}")
+    IO.puts("hidden_local_burst_rows=#{data.hidden_local_burst_rows}")
+    IO.puts("limit=#{data.limit}")
+    IO.puts("iterations=#{data.iterations}")
+    IO.puts("warmup_runs=#{data.warmup_runs}")
+    IO.puts("pagination_hard_max_limit=#{data.pagination_hard_max_limit}")
+    IO.puts("fast_seed=#{data.fast_seed?}")
+    IO.puts("keep_rows=#{data.keep_rows?}")
+    IO.puts("vacuum_after_churn=#{data.vacuum_after_churn?}")
+    IO.puts("vacuum_after_seed=#{data.vacuum_after_seed?}")
+    IO.puts("seed_integrity_missing=#{inspect(data.seed_integrity)}")
+    IO.puts("counts=#{inspect(data.counts)}")
+    IO.puts("relation_sizes=#{inspect(data.relation_sizes)}")
+    IO.puts("requirements=#{inspect(data.requirements)}")
+    print_optional_timing("cold_first", data.cold_first_timing)
+    IO.puts("warmup_timing_ms=#{inspect(format_timings(data.warmup_timings))}")
+    IO.puts("first_edge_count=#{first_edge_count}")
+    IO.puts("first_timing_ms=#{Float.round(first_timing, 2)}")
+    IO.puts("edge_counts=#{inspect(edge_counts)}")
+    IO.puts("timing_ms=#{inspect(Enum.map(timings, &Float.round(&1, 2)))}")
+    IO.puts("median_ms=#{Float.round(percentile(timings, 0.5), 2)}")
+    IO.puts("p95_ms=#{Float.round(percentile(timings, 0.95), 2)}")
+    IO.puts("page_walk=#{inspect(format_page_walk(data.page_walk), limit: :infinity)}")
+    IO.puts("page_max_ms=#{Float.round(Enum.max(page_timings, fn -> 0.0 end), 2)}")
+    IO.puts("page_p95_ms=#{Float.round(percentile(page_timings, 0.95), 2)}")
+    IO.puts("feed_publish_target_index_used=#{data.plan_flags.feed_publish_target_index_used}")
+    IO.puts("feed_publish_pkey_used=#{data.plan_flags.feed_publish_pkey_used}")
+    IO.puts("feed_publish_seq_scan_used=#{data.plan_flags.feed_publish_seq_scan_used}")
+    IO.puts("feed_publish_plan_metrics=#{inspect(data.plan_metrics)}")
+    IO.puts("indexes=#{inspect(data.index_info)}")
+    IO.puts("explain_page=#{data.requirements.explain_page}")
+    IO.puts("explain_begin")
+    IO.puts(data.explain)
+    IO.puts("explain_end")
+  end
+
+  defp format_page_walk(page_walk) do
+    Enum.map(page_walk, fn page ->
+      %{
+        duplicate_count: page.duplicate_count,
+        edge_count: page.edge_count,
+        has_end_cursor: is_binary(page.end_cursor),
+        page: page.page,
+        timing_ms: Float.round(page.timing_ms, 2)
+      }
+    end)
+  end
+
+  defp print_optional_timing(_label, nil), do: :ok
+
+  defp print_optional_timing(label, {timing_ms, edge_count}) do
+    IO.puts("#{label}_edge_count=#{edge_count}")
+    IO.puts("#{label}_timing_ms=#{Float.round(timing_ms, 2)}")
+  end
+
+  defp format_timings(timings) do
+    Enum.map(timings, fn {timing_ms, edge_count} ->
+      %{edge_count: edge_count, timing_ms: Float.round(timing_ms, 2)}
+    end)
+  end
+
+  defp enforce_requirements!(data) do
+    timings = Enum.map(data.timings, &elem(&1, 0))
+    edge_counts = Enum.map(data.timings, &elem(&1, 1))
+    {first_timing, first_edge_count} = data.first_timing
+    p95 = percentile(timings, 0.95)
+    page_timings = Enum.map(data.page_walk, & &1.timing_ms)
+    page_max = Enum.max(page_timings, fn -> 0.0 end)
+    page_p95 = percentile(page_timings, 0.95)
+    feed_publish_rows = feed_publish_rows(data.counts)
+    hidden_local_rows = hidden_local_rows(data.counts)
+    visible_local_rows = visible_local_rows(data.counts)
+    requirements = data.requirements
+    cold_first_ms = timing_ms(data.cold_first_timing)
+    bounded_feed_publish_index? = bounded_feed_publish_index?(data)
+
+    []
+    |> add_error(
+      requirements.require_target_index? and
+        not bounded_feed_publish_index?,
+      "expected benchmark plan to use a bounded feed_publish index path"
+    )
+    |> add_error(
+      requirements.require_no_feed_publish_seq_scan? and
+        data.plan_flags.feed_publish_seq_scan_used,
+      "expected benchmark plan not to use a sequential scan on bonfire_data_social_feed_publish"
+    )
+    |> add_error(
+      requirements.require_no_temp_blocks? and data.plan_metrics.plan_temp_blocks != 0,
+      "expected benchmark plan not to spill temp blocks, got #{data.plan_metrics.plan_temp_blocks}"
+    )
+    |> add_error(
+      requirements.exact_feed_publish_rows &&
+        feed_publish_rows != requirements.exact_feed_publish_rows,
+      "expected exactly #{requirements.exact_feed_publish_rows} synthetic feed_publish rows, got #{feed_publish_rows}"
+    )
+    |> add_error(
+      requirements.require_full_page? and first_edge_count != requirements.limit,
+      "expected first run to return #{requirements.limit} edges, got #{first_edge_count}"
+    )
+    |> add_error(
+      requirements.require_full_page? and Enum.any?(edge_counts, &(&1 != requirements.limit)),
+      "expected every warm run to return #{requirements.limit} edges, got #{inspect(edge_counts)}"
+    )
+    |> add_error(
+      requirements.require_full_page? and
+        Enum.any?(data.page_walk, &(&1.edge_count != requirements.limit)),
+      "expected every walked page to return #{requirements.limit} edges, got #{inspect(Enum.map(data.page_walk, & &1.edge_count))}"
+    )
+    |> add_error(
+      Enum.any?(data.page_walk, &(&1.duplicate_count != 0)),
+      "expected walked pages not to overlap, got duplicate counts #{inspect(Enum.map(data.page_walk, & &1.duplicate_count))}"
+    )
+    |> add_error(
+      requirements.min_visible_local_rows &&
+        visible_local_rows < requirements.min_visible_local_rows,
+      "expected at least #{requirements.min_visible_local_rows} visible local rows, got #{visible_local_rows}"
+    )
+    |> add_error(
+      requirements.min_hidden_local_rows &&
+        hidden_local_rows < requirements.min_hidden_local_rows,
+      "expected at least #{requirements.min_hidden_local_rows} hidden local rows, got #{hidden_local_rows}"
+    )
+    |> add_error(
+      requirements.max_feed_publish_actual_rows &&
+        data.plan_metrics.feed_publish_actual_rows > requirements.max_feed_publish_actual_rows,
+      "expected feed_publish actual rows <= #{requirements.max_feed_publish_actual_rows}, got #{Float.round(data.plan_metrics.feed_publish_actual_rows, 2)}"
+    )
+    |> add_error(
+      requirements.max_feed_publish_heap_fetches &&
+        data.plan_metrics.feed_publish_heap_fetches > requirements.max_feed_publish_heap_fetches,
+      "expected feed_publish heap fetches <= #{requirements.max_feed_publish_heap_fetches}, got #{data.plan_metrics.feed_publish_heap_fetches}"
+    )
+    |> add_error(
+      requirements.max_feed_publish_rows_removed_by_filter &&
+        data.plan_metrics.feed_publish_rows_removed_by_filter >
+          requirements.max_feed_publish_rows_removed_by_filter,
+      "expected feed_publish rows removed by filter <= #{requirements.max_feed_publish_rows_removed_by_filter}, got #{data.plan_metrics.feed_publish_rows_removed_by_filter}"
+    )
+    |> add_error(
+      requirements.max_cold_first_ms && cold_first_ms > requirements.max_cold_first_ms,
+      "expected cold first run <= #{requirements.max_cold_first_ms}ms, got #{Float.round(cold_first_ms, 2)}ms"
+    )
+    |> add_error(
+      requirements.max_first_ms && first_timing > requirements.max_first_ms,
+      "expected first run <= #{requirements.max_first_ms}ms, got #{Float.round(first_timing, 2)}ms"
+    )
+    |> add_error(
+      requirements.max_p95_ms && p95 > requirements.max_p95_ms,
+      "expected p95 <= #{requirements.max_p95_ms}ms, got #{Float.round(p95, 2)}ms"
+    )
+    |> add_error(
+      requirements.max_page_p95_ms && page_p95 > requirements.max_page_p95_ms,
+      "expected walked-page p95 <= #{requirements.max_page_p95_ms}ms, got #{Float.round(page_p95, 2)}ms"
+    )
+    |> add_error(
+      requirements.max_page_ms && page_max > requirements.max_page_ms,
+      "expected every walked page <= #{requirements.max_page_ms}ms, max was #{Float.round(page_max, 2)}ms"
+    )
+    |> case do
+      [] ->
+        IO.puts("requirements_status=passed")
+
+      errors ->
+        IO.puts("requirements_status=failed")
+        raise Enum.join(Enum.reverse(errors), "\n")
+    end
+  end
+
+  defp add_error(errors, true, message), do: [message | errors]
+  defp add_error(errors, _, _message), do: errors
+
+  defp hidden_local_rows([[_, _, hidden_local_rows, _, _, _] | _]), do: hidden_local_rows
+  defp hidden_local_rows(_), do: 0
+
+  defp visible_local_rows([[_, _, _, _, visible_local_rows, _] | _]), do: visible_local_rows
+  defp visible_local_rows(_), do: 0
+
+  defp feed_publish_rows([[_, _, _, _, _, feed_publish_rows] | _]), do: feed_publish_rows
+  defp feed_publish_rows(_), do: 0
+
+  defp bounded_feed_publish_index?(data) do
+    data.plan_flags.feed_publish_target_index_used ||
+      (data.plan_flags.feed_publish_pkey_used &&
+         data.plan_metrics.feed_publish_actual_rows <= bounded_feed_publish_rows_limit(data))
+  end
+
+  defp bounded_feed_publish_rows_limit(data) do
+    data.requirements.max_feed_publish_actual_rows || data.limit * 4
+  end
+
+  defp timing_ms({timing_ms, _edge_count}), do: timing_ms
+  defp timing_ms(_), do: 0.0
+
+  defp percentile([], _), do: 0.0
+
+  defp percentile(values, percentile) do
+    sorted = Enum.sort(values)
+    index = max(ceil(length(sorted) * percentile) - 1, 0)
+    Enum.at(sorted, index)
+  end
+
+  defp env_int(name, default) do
+    case System.get_env(name) do
+      nil -> default
+      "" -> default
+      value -> String.to_integer(value)
+    end
+  end
+
+  defp env_optional_float(name) do
+    case System.get_env(name) do
+      nil ->
+        nil
+
+      "" ->
+        nil
+
+      value ->
+        case Float.parse(value) do
+          {float, ""} -> float
+          _ -> raise "Expected #{name} to be a number, got #{inspect(value)}"
+        end
+    end
+  end
+
+  defp env_optional_int(name) do
+    case System.get_env(name) do
+      nil -> nil
+      "" -> nil
+      value -> String.to_integer(value)
+    end
+  end
+end
+
+Bonfire.ClassicFeedBenchmark.run()

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -35,6 +35,11 @@ System.get_env("DATABASE_URL") || System.get_env("CLOUDRON_POSTGRESQL_URL") ||
   """
 
 ## load extensions' runtime configs (and behaviours) directly via extension-provided modules
+if System.get_env("BONFIRE_LIGHTWEIGHT_TEST_SETUP") == "1" and
+     not Code.ensure_loaded?(Bonfire.RuntimeConfig) do
+  Code.compile_file(Path.expand("../lib/bonfire/runtime_config.ex", __DIR__))
+end
+
 Bonfire.Common.Config.LoadExtensionsConfig.load_configs([Bonfire.RuntimeConfig])
 ##
 
@@ -91,7 +96,7 @@ phx_compress? = System.get_env("PHX_COMPRESS_HTTP") not in no?
 
 if System.get_env("DISABLE_LOG") in yes? do
   # to suppress non-captured logs in tests (eg. in setup_all)
-  config :logger, backends: []
+  config :logger, :default_handler, false
 end
 
 http_options =
@@ -141,7 +146,7 @@ config :bonfire, Bonfire.Web.Endpoint,
     port: public_port,
     scheme: if(public_port == 443, do: "https", else: "http")
   ],
-  check_origin: hosts, 
+  check_origin: hosts,
   # check_origin: false,
   adapter:
     if(use_cowboy?,

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,6 +5,7 @@ no? = ~w(false no 0)
 
 test_instance? = System.get_env("TEST_INSTANCE") in yes?
 federate? = test_instance? or System.get_env("FEDERATE") in yes?
+lightweight_test? = System.get_env("BONFIRE_LIGHTWEIGHT_TEST_SETUP") == "1"
 
 ## Import or set test configs for extensions
 
@@ -16,6 +17,29 @@ config :bonfire,
   pagination_hard_max_limit: 20,
   skip_all_boundary_checks: false,
   ui: [infinite_scroll: false]
+
+if lightweight_test? do
+  repo_config = [
+    database: System.get_env("POSTGRES_DB", "bonfire_test"),
+    username: System.get_env("POSTGRES_USER", "postgres"),
+    password: System.get_env("POSTGRES_PASSWORD", "postgres"),
+    hostname: System.get_env("POSTGRES_HOST", "localhost"),
+    port: System.get_env("POSTGRES_PORT", "5432") |> String.to_integer(),
+    types: Postgrex.DefaultTypes,
+    timeout: System.get_env("DB_QUERY_TIMEOUT", "20000") |> String.to_integer(),
+    pool_timeout: System.get_env("DB_POOL_TIMEOUT", "30000") |> String.to_integer(),
+    ownership_timeout: System.get_env("DB_OWNERSHIP_TIMEOUT", "100000") |> String.to_integer(),
+    queue_target: System.get_env("DB_QUEUE_TARGET", "5000") |> String.to_integer(),
+    queue_interval: System.get_env("DB_QUEUE_INTERVAL", "2000") |> String.to_integer(),
+    parameters: [
+      statement_timeout: System.get_env("DB_STATEMENT_TIMEOUT", "20000"),
+      idle_in_transaction_session_timeout: System.get_env("DB_IDLE_TRANSACTION_TIMEOUT", "120000")
+    ]
+  ]
+
+  config :bonfire, Bonfire.Common.Repo, repo_config
+  config :bonfire, Bonfire.Common.TestInstanceRepo, repo_config
+end
 
 config :bonfire_mailer, Bonfire.Mailer.Bamboo, adapter: Bamboo.TestAdapter
 config :bonfire_mailer, Bonfire.Mailer.Swoosh, adapter: Swoosh.Adapters.Test
@@ -47,7 +71,7 @@ config :logger, :console, truncate: truncate
 if !test_instance? and System.get_env("CAPTURE_LOG") not in no? and
      System.get_env("UNTANGLE_TO_IO") not in yes? do
   # to suppress non-captured logs in tests (eg. in setup_all)
-  config :logger, backends: []
+  config :logger, :default_handler, false
 end
 
 if !federate? do
@@ -58,8 +82,8 @@ end
 # Configure Req.Test stubs
 config :bonfire_rss, :req_options, plug: {Req.Test, Bonfire.RSS}
 
-#  enable federation in tests, since we're either using mocks or integration testing with TEST_INSTANCE 
-config :activity_pub, :instance, federating: true
+# enable federation in full tests; lightweight local setup only enables it when explicitly requested
+config :activity_pub, :instance, federating: if(lightweight_test?, do: federate?, else: true)
 
 oban_mode = if(federate?, do: :inline, else: :manual)
 config :bonfire, Oban, testing: oban_mode

--- a/docs/topics/BONFIRE_PAGINATION_GUIDE.md
+++ b/docs/topics/BONFIRE_PAGINATION_GUIDE.md
@@ -259,6 +259,94 @@ When implementing pagination, ensure you handle:
 - Missing context for multiple lists
 - Not validating user permissions for pagination
 
+### Deferred Join Regression Checks
+
+Run these focused checks from the Bonfire app umbrella when changing feed deferred-join pagination or load-more behavior:
+
+When submitting this change across separate repositories, keep the dependency order explicit: `bonfire_common` must include the lightweight test repo guards used by this harness, `bonfire_data_social` must provide `Bonfire.Data.Social.FeedPublish.Migration.add_feed_publish_feed_id_id_index/1` and `Bonfire.Data.Social.Activity.Migration.add_activity_feed_lookup_index/1` before the `bonfire_social` migrations that call them are deployed, and the app umbrella harness assumes sibling checkouts for `bonfire_common`, `bonfire_data_social`, `bonfire_social`, and `bonfire_ui_social`.
+
+```bash
+./test-pagination-regression.sh backend
+```
+
+```bash
+./test-pagination-regression.sh ui
+```
+
+```bash
+./test-pagination-regression.sh ui-presets
+```
+
+```bash
+./test-pagination-regression.sh ui-context
+```
+
+```bash
+./test-pagination-regression.sh ui-auto-short-feed
+```
+
+```bash
+./test-pagination-regression.sh ui-actual-cases
+```
+
+```bash
+./test-pagination-regression.sh ui-time-limit
+```
+
+```bash
+./test-pagination-regression.sh ui-benchmark-target
+```
+
+```bash
+./test-pagination-regression.sh ui-full-preload-render-stress
+```
+
+```bash
+./test-pagination-regression.sh classic-benchmark
+```
+
+Use `./test-pagination-regression.sh all` to run formatting plus the backend, focused UI, real feed preset load-more, group context leakage, short-feed auto-pagination, deferred-join actual-case, show-older time-limit persistence, and feed benchmark target checks serially. The `ui-time-limit` check targets the tagged show-older date-sorted, non-date sorted, cached-feed, and guest fallback cases. Use `./test-pagination-regression.sh ui-full-preload-render-stress` for the heavier UI path that seeds two 20-item visible local pages separated by a hidden local window, runs the no-time-limit full-preload backend path, renders that same full-preloaded feed component, then renders `/feed/local` and `load_more` through PhoenixTest. That stress also fails if the deferred-join code falls back to the non-deferred query path while recovering the page; it scopes a longer DB ownership timeout to this target because strict fixture setup can outlive the ordinary sandbox default. Use `./test-pagination-regression.sh ui-browser-js` for the real Chromium guest fallback check; it starts the test endpoint with `PHX_SERVER=yes`, uses a non-sandbox test DB checkout, opens both cache-bypassed and cache-enabled `/feed/?time_limit=1` guest flows, clicks the disconnected `load_all_time` anchor and `next_page` link, and fails on browser `pageerror` or `console.error`. Use `./test-pagination-regression.sh all-with-strict-benchmark` as the local pre-release gate when you also need the full preload/render stress, real browser JS check, the 1,000,000-row sparse/hidden Classic-like benchmark, the 1,000,000-row all-local benchmark, and the guest-visible custom ACL stress profile. The script sets a focused lightweight local test environment and forces the social flavour with AI disabled. Only the strict Classic benchmark branch relaxes local test DB query/pool/ownership timeouts and disables server-side statement timeout so large fixture setup or adversarial page walks are not confused with the separate 222ms benchmark gates. It accepts normal database overrides such as `POSTGRES_DB=...` or `DATABASE_URL=...`; when `DATABASE_URL` is provided, its database/user/password/host/port seed the corresponding `POSTGRES_*` defaults, and conflicting `POSTGRES_DB` values are rejected before migrations run. It creates and strictly migrates the configured test database, rejects any non-success extension migration result, refuses database names that do not look like test databases unless `BONFIRE_ALLOW_NON_TEST_DATABASE=1` is set for an intentional throwaway database, and uses a checkout-local lock with a bounded wait to avoid concurrent runs sharing this checkout's `_build/test` state or default test database. This harness is focused regression coverage, not a substitute for a full non-lightweight application run on maintainer hardware; browser paint and logged-in websocket flows still need review if a later change touches those surfaces.
+
+Full preload/render stress knobs:
+
+```bash
+BONFIRE_FULL_RENDER_PAGE_LIMIT=20 \
+BONFIRE_FULL_RENDER_HIDDEN_MULTIPLIER=32 \
+BONFIRE_FULL_RENDER_HIDDEN_EXTRA_ROWS=5 \
+BONFIRE_FULL_PRELOAD_MAX_MS=1000 \
+BONFIRE_FULL_COMPONENT_RENDER_MAX_MS=3000 \
+BONFIRE_FULL_INITIAL_RENDER_MAX_MS=5000 \
+BONFIRE_FULL_LOAD_MORE_RENDER_MAX_MS=3000 \
+./test-pagination-regression.sh ui-full-preload-render-stress
+```
+
+The full preload/render timing gates are integration-regression guards, not the 222ms query target. The 222ms target belongs to the Classic-like query benchmark, while the PhoenixTest timings include full preloads, LiveView rendering, event handling, and test harness overhead.
+
+### Feed Backend Benchmark
+
+Use `Bonfire.UI.Social.Benchmark.feed_backend/0` to compare local feed query timings. The review target is the `query 20 with no time limit` case: guest local feed, page size 20, no time filter, normal boundary checks, and the default feed query path. Diagnostic cases such as `without deferred join` and `ignoring boundaries` are useful for comparison, but they should not be treated as the user-facing target.
+
+### Classic-like Feed Benchmark
+
+Use `./test-pagination-regression.sh classic-benchmark` when the maintainer's Classic database or hardware is not available. The benchmark seeds a test database with synthetic local-feed activity, remote/noise feed rows, fetcher-subject rows, and public ACL rows, then runs the real `FeedActivities.feed(:local, limit: 20, preload: false)` query path with normal boundary checks. This is a query microbenchmark, not a full UI/rendering benchmark. It prints counts, edge counts, first-run and warm-cache timings, relevant feed-publish indexes, whether the `(feed_id, id)` index appears in the plan, and `EXPLAIN (ANALYZE, BUFFERS)` output.
+
+Useful knobs:
+
+```bash
+BONFIRE_CLASSIC_FEED_ROWS=200000 \
+BONFIRE_CLASSIC_BENCH_ITERATIONS=3 \
+BONFIRE_CLASSIC_BENCH_WORK_MEM=4MB \
+BONFIRE_CLASSIC_BENCH_EFFECTIVE_CACHE_SIZE=128MB \
+BONFIRE_CLASSIC_BENCH_RANDOM_PAGE_COST=4 \
+./test-pagination-regression.sh classic-benchmark
+```
+
+Set `BONFIRE_CLASSIC_LOCAL_EVERY=493` to make only every 493rd synthetic activity become a public local-feed item. Set `BONFIRE_CLASSIC_HIDDEN_LOCAL_EVERY=23` to add many local-feed rows that fail ACL visibility checks. Set `BONFIRE_CLASSIC_HIDDEN_LOCAL_BURST_ROWS=5000` to make the newest local-feed slice hidden rather than evenly distributed. That sparse, hidden, and bursty mode is useful for checking whether the query still avoids scanning through many recent non-local rows, hidden local rows, and fetcher-subject rows while still returning visible local results.
+
+Use `./test-pagination-regression.sh classic-benchmark-stress` when validating against a stricter Classic-like case before submission. It runs against a throwaway test database, defaulting to `bonfire_test_classic_stress`, and drops that database before and after the run instead of doing large in-place cleanup. The stress command also installs an `EXIT` cleanup trap and wraps the benchmark with `BONFIRE_CLASSIC_STRESS_TIMEOUT_SECONDS`, defaulting to 1800 seconds, so hung seed/query/EXPLAIN runs fail instead of waiting forever. It defaults to 1,000,000 synthetic feed rows, only every 493rd row as a public local-feed item, hidden local-feed rows every 23rd item, a 5,000-row hidden local burst at the newest end of the synthetic range, a fetcher-noise cadence that does not align with the local-feed cadence, 250,000 inserted-then-deleted newer local-feed rows to exercise hot target-index churn, `VACUUM (ANALYZE)` after churn and after the main seed to represent a maintained database with usable visibility-map coverage, one cold-path diagnostic feed run, low `work_mem`, low `effective_cache_size`, and `random_page_cost=4`. The stress target uses `BONFIRE_CLASSIC_FAST_SEED=1` by default so the expensive synthetic setup can bypass trigger overhead, then verifies exact seed row count and table integrity before timing the real query path. It requires 90 full 20-edge cursor pages with no overlap, at least 2,000 visible local rows, at least 40,000 hidden local rows, use of `bonfire_data_social_feed_publish_feed_id_id_idx` on the deep-page plan, no feed-publish sequential scan, no whole-plan temp-block spill, bounded feed-publish plan row volume, tightly bounded heap fetches and rows removed by filter, first measured query time under 222ms after the diagnostic warmup, warm p95 under 222ms, every walked page under 222ms, and walked-page p95 under 222ms.
+
+Use `./test-pagination-regression.sh classic-benchmark-local-heavy` to validate the separate 1,000,000-local-candidate profile. That profile makes every synthetic row a visible local-feed candidate, keeps the same 20-edge and 90-page timing gates, and disables the target-index requirement because `feed_id` is intentionally non-selective in an all-local dataset; the sparse stress profile remains the target-index proof. Use `./test-pagination-regression.sh classic-benchmark-guest-visible-acl-stress` to validate anonymous local-feed rows protected by the `guests_may_see_read` ACL path under a stricter sparse profile: 1,000,000 feed rows, 100,000 hidden newest local rows, 250,000 churn rows, 120 cursor pages, low `work_mem`, low `effective_cache_size`, and `random_page_cost=4`. Use `./test-pagination-regression.sh all-with-strict-benchmark` to run the full preload/render stress and all three strict benchmark profiles after the formatting, backend, and UI checks. Set `BONFIRE_CLASSIC_VACUUM_AFTER_CHURN=0` or `BONFIRE_CLASSIC_VACUUM_AFTER_SEED=0` only when intentionally measuring unmaintained-table risk; that case can fail the cold-path or first-run wall-clock gate even when the query shape is correct. Override other limits with the matching `BONFIRE_CLASSIC_*` environment variables only when documenting why local hardware needs a different gate.
+
 ## Debug Helpers
 
 ### Common Issues:

--- a/lib/mix/mixer.ex
+++ b/lib/mix/mixer.ex
@@ -395,18 +395,23 @@ if not Code.ensure_loaded?(Bonfire.Mixer) do
         |> String.replace("%{path}", "#{path}")
         |> String.replace("%{line}", "#{line}")
 
+    def lightweight_test_setup?,
+      do: System.get_env("BONFIRE_LIGHTWEIGHT_TEST_SETUP") == "1"
+
     # Specifies which paths to include when running tests
     def test_paths(config) do
-      testable_paths =
-        test_deps(config)
-        |> Enum.flat_map(&dep_paths(&1, "test"))
+      if lightweight_test_setup?() do
+        ["test"]
+      else
+        testable_paths =
+          test_deps(config)
+          |> Enum.flat_map(&dep_paths(&1, "test"))
 
-      # |> IO.inspect(label: "testable_paths")
-
-      [
-        "test"
-        | testable_paths
-      ]
+        [
+          "test"
+          | testable_paths
+        ]
+      end
     end
 
     def test_deps(config) do
@@ -445,16 +450,27 @@ if not Code.ensure_loaded?(Bonfire.Mixer) do
       # |> log("all_testable_deps")
 
       testable_paths =
-        case find_matching_paths(paths_to_test, all_testable_deps) do
-          [] -> all_testable_deps
-          testable_paths -> testable_paths
+        if lightweight_test_setup?() do
+          all_testable_deps
+        else
+          case find_matching_paths(paths_to_test, all_testable_deps) do
+            [] -> all_testable_deps
+            testable_paths -> testable_paths
+          end
         end
+
+      dep_support_paths =
+        testable_paths
+        |> dep_paths("test/support")
+        |> Enum.map(fn
+          "../" <> _ = path -> Path.expand(path)
+          path -> path
+        end)
 
       [
         "lib",
         "test/support"
-        | dep_paths(testable_paths, "test/support")
-        # |> log("elixirc_paths")
+        | dep_support_paths
       ]
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -643,7 +643,11 @@ defmodule Bonfire.Umbrella.MixProject do
   def application do
     # Bonfire.MixProject.application()
     [
-      mod: {Bonfire.Application, []},
+      mod:
+        if(Mix.env() == :test and System.get_env("BONFIRE_LIGHTWEIGHT_TEST_SETUP") == "1",
+          do: {Bonfire.LightweightTestApplication, []},
+          else: {Bonfire.Application, []}
+        ),
       extra_applications: [:logger, :runtime_tools]
     ]
   end

--- a/test-pagination-regression.sh
+++ b/test-pagination-regression.sh
@@ -1,0 +1,398 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_path="$(readlink -f "${BASH_SOURCE[0]}")"
+
+cd "$(dirname "$script_path")"
+
+if [[ "${BONFIRE_PAGINATION_LOCK_HELD:-0}" != "1" && "${BONFIRE_PAGINATION_SKIP_LOCK:-0}" != "1" ]]; then
+  lock_file="${BONFIRE_PAGINATION_LOCK_FILE:-$PWD/.bonfire-pagination-regression.lock}"
+  exec 9>"$lock_file"
+
+  if command -v flock >/dev/null 2>&1; then
+    lock_timeout="${BONFIRE_PAGINATION_LOCK_TIMEOUT_SECONDS:-600}"
+    if ! flock -w "$lock_timeout" 9; then
+      echo "Another pagination regression run is using this checkout. Lock file: $lock_file" >&2
+      echo "Wait for it to finish, or set BONFIRE_PAGINATION_LOCK_FILE to isolate a separate checkout/database." >&2
+      exit 75
+    fi
+    export BONFIRE_PAGINATION_LOCK_HELD=1
+  else
+    echo "Warning: flock is unavailable; do not run this script concurrently in the same checkout/database." >&2
+  fi
+fi
+
+database_url_was_set=0
+postgres_db_was_set=0
+
+if [[ -v DATABASE_URL ]]; then
+  database_url_was_set=1
+  database_url="$DATABASE_URL"
+else
+  database_url="ecto://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-localhost}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-bonfire_test}"
+fi
+
+if [[ -v POSTGRES_DB ]]; then
+  postgres_db_was_set=1
+fi
+
+url_path="${database_url#*://}"
+url_auth_host="${url_path%%/*}"
+url_database="${url_path#*/}"
+url_database="${url_database%%\?*}"
+url_host_port="${url_auth_host##*@}"
+url_host="${url_host_port%%:*}"
+url_port=""
+url_auth=""
+url_user=""
+url_password=""
+
+if [[ "$url_host_port" == *:* ]]; then
+  url_port="${url_host_port##*:}"
+fi
+
+if [[ "$url_auth_host" != "$url_host_port" ]]; then
+  url_auth="${url_auth_host%@*}"
+fi
+
+if [[ -n "$url_auth" ]]; then
+  if [[ "$url_auth" == *:* ]]; then
+    url_user="${url_auth%%:*}"
+    url_password="${url_auth#*:}"
+  else
+    url_user="$url_auth"
+  fi
+fi
+
+if [[ "$database_url_was_set" == "1" && "$postgres_db_was_set" == "1" && "$POSTGRES_DB" != "$url_database" ]]; then
+  echo "DATABASE_URL targets database '$url_database' but POSTGRES_DB is '$POSTGRES_DB'." >&2
+  echo "Unset POSTGRES_DB or make it match DATABASE_URL before running the pagination regression script." >&2
+  exit 64
+fi
+
+export DATABASE_URL="$database_url"
+export POSTGRES_USER="${POSTGRES_USER:-${url_user:-postgres}}"
+export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-${url_password:-postgres}}"
+export POSTGRES_HOST="${POSTGRES_HOST:-${url_host:-localhost}}"
+export POSTGRES_PORT="${POSTGRES_PORT:-${url_port:-5432}}"
+export POSTGRES_DB="${POSTGRES_DB:-${url_database:-bonfire_test}}"
+export DB_MIGRATE_INDEXES_CONCURRENTLY="${DB_MIGRATE_INDEXES_CONCURRENTLY:-false}"
+export SECRET_KEY_BASE="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+export SIGNING_SALT="bbbbbbbbbbbbbbbb"
+export ENCRYPTION_SALT="cccccccccccccccc"
+export MIX_ENV=test
+export MIX_QUIET="${MIX_QUIET:-1}"
+export DISABLE_LOG="${DISABLE_LOG:-true}"
+export FLAVOUR=social
+export WITH_DOCKER="${WITH_DOCKER:-no}"
+export WITH_AI="${WITH_AI:-0}"
+export TEST_WITH_MNEME="${TEST_WITH_MNEME:-no}"
+export BONFIRE_LIGHTWEIGHT_TEST_SETUP=1
+export BONFIRE_LIGHTWEIGHT_TEST_MIGRATE=1
+
+if [[ "${BONFIRE_ALLOW_NON_TEST_DATABASE:-0}" != "1" && "$url_database" != *"_test"* ]]; then
+  echo "Refusing to create/migrate DATABASE_URL target '$url_database' because it does not look like a test database." >&2
+  echo "Set BONFIRE_ALLOW_NON_TEST_DATABASE=1 only for an intentional throwaway database." >&2
+  exit 64
+fi
+
+if command -v pg_isready >/dev/null 2>&1 &&
+  ! pg_isready -q -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER"; then
+  echo "Postgres is not reachable at $POSTGRES_HOST:$POSTGRES_PORT for user $POSTGRES_USER." >&2
+  echo "Set DATABASE_URL or POSTGRES_* to a running local test database." >&2
+  exit 69
+fi
+
+run_mix() {
+  if command -v mise >/dev/null 2>&1; then
+    mise exec -- mix "$@"
+  elif [ -x "$HOME/.local/bin/mise" ]; then
+    "$HOME/.local/bin/mise" exec -- mix "$@"
+  else
+    mix "$@"
+  fi
+}
+
+run_mix_with_timeout() {
+  timeout_seconds="$1"
+  shift
+
+  if command -v timeout >/dev/null 2>&1; then
+    if command -v mise >/dev/null 2>&1; then
+      timeout --kill-after=30s --preserve-status "$timeout_seconds" mise exec -- mix "$@"
+    elif [ -x "$HOME/.local/bin/mise" ]; then
+      timeout --kill-after=30s --preserve-status "$timeout_seconds" "$HOME/.local/bin/mise" exec -- mix "$@"
+    else
+      timeout --kill-after=30s --preserve-status "$timeout_seconds" mix "$@"
+    fi
+  else
+    echo "Warning: timeout is unavailable; benchmark will rely on its internal timing gates only." >&2
+    run_mix "$@"
+  fi
+}
+
+run_format_check() {
+  run_mix format --check-formatted "${format_targets[@]}"
+}
+
+run_test() {
+  run_mix test --force "$@" --trace
+}
+
+format_targets=(
+  config/runtime.exs
+  config/test.exs
+  lib/mix/mixer.ex
+  mix.exs
+  benchmarks/classic_feed_benchmark.exs
+  test/test_helper.exs
+  test/support/lightweight_test_application.ex
+  ../bonfire_common/lib/repo/test_instance_repo.ex
+  ../bonfire_common/lib/runtime_config.ex
+  ../bonfire_common/test/support/nebulex_cache_test.ex
+  ../bonfire_data_social/lib/activity.ex
+  ../bonfire_data_social/lib/feed_publish.ex
+  ../bonfire_social/lib/feed_loader.ex
+  ../bonfire_social/lib/runtime_config.ex
+  ../bonfire_social/priv/repo/migrations/20260516000100_add_feed_publish_feed_id_id_index.exs
+  ../bonfire_social/priv/repo/migrations/20260516000200_add_activity_feed_lookup_index.exs
+  ../bonfire_social/test/feeds/feed_query_pagination_test.exs
+  ../bonfire_ui_social/lib/benchmark.ex
+  ../bonfire_ui_social/lib/live_handlers/feeds_live_handler.ex
+  ../bonfire_ui_social/test/views/pagination/deferred_join_actual_cases_test.exs
+  ../bonfire_ui_social/test/views/pagination/feed_load_more_remove_time_filter_test.exs
+  ../bonfire_ui_social/test/views/pagination/feed_backend_benchmark_target_test.exs
+  ../bonfire_ui_social/test/views/pagination/feed_full_preload_render_stress_test.exs
+  ../bonfire_ui_social/test/views/pagination/feed_browser_js_time_limit_test.exs
+  ../bonfire_ui_social/test/views/pagination/feed_auto_pagination_short_feed_test.exs
+  ../bonfire_ui_social/test/views/pagination/load_more_context_attr_test.exs
+  ../bonfire_ui_social/test/views/pagination/load_more_with_deferred_join.exs
+)
+
+case "${1:-all}" in
+  format)
+    unset MIX_TEST_ONLY
+    run_format_check
+    ;;
+  backend)
+    export MIX_TEST_ONLY=backend
+    run_test ../bonfire_social/test/feeds/feed_query_pagination_test.exs
+    ;;
+  ui)
+    export MIX_TEST_ONLY=ui
+    run_test ../bonfire_ui_social/test/views/pagination/load_more_with_deferred_join.exs
+    ;;
+  ui-presets)
+    export MIX_TEST_ONLY=ui
+    run_test ../bonfire_ui_social/test/views/pagination/feed_presets_load_more_test.exs
+    ;;
+  ui-context)
+    export MIX_TEST_ONLY=ui
+    run_test ../bonfire_ui_social/test/views/pagination/load_more_context_attr_test.exs
+    ;;
+  ui-auto-short-feed)
+    export MIX_TEST_ONLY=ui
+    run_test ../bonfire_ui_social/test/views/pagination/feed_auto_pagination_short_feed_test.exs
+    ;;
+  ui-actual-cases)
+    export MIX_TEST_ONLY=ui
+    run_test ../bonfire_ui_social/test/views/pagination/deferred_join_actual_cases_test.exs
+    ;;
+  ui-time-limit)
+    export MIX_TEST_ONLY=ui
+    run_test ../bonfire_ui_social/test/views/pagination/feed_load_more_remove_time_filter_test.exs --only pagination_time_limit
+    ;;
+  ui-benchmark-target)
+    export MIX_TEST_ONLY=ui
+    run_test ../bonfire_ui_social/test/views/pagination/feed_backend_benchmark_target_test.exs
+    ;;
+  ui-full-preload-render-stress)
+    export MIX_TEST_ONLY=ui
+    export BONFIRE_FULL_RENDER_PAGE_LIMIT="${BONFIRE_FULL_RENDER_PAGE_LIMIT:-20}"
+    export BONFIRE_FULL_RENDER_HIDDEN_MULTIPLIER="${BONFIRE_FULL_RENDER_HIDDEN_MULTIPLIER:-32}"
+    export BONFIRE_FULL_RENDER_HIDDEN_EXTRA_ROWS="${BONFIRE_FULL_RENDER_HIDDEN_EXTRA_ROWS:-5}"
+    export BONFIRE_FULL_PRELOAD_MAX_MS="${BONFIRE_FULL_PRELOAD_MAX_MS:-1000}"
+    export BONFIRE_FULL_COMPONENT_RENDER_MAX_MS="${BONFIRE_FULL_COMPONENT_RENDER_MAX_MS:-3000}"
+    export BONFIRE_FULL_INITIAL_RENDER_MAX_MS="${BONFIRE_FULL_INITIAL_RENDER_MAX_MS:-5000}"
+    export BONFIRE_FULL_LOAD_MORE_RENDER_MAX_MS="${BONFIRE_FULL_LOAD_MORE_RENDER_MAX_MS:-3000}"
+    export DB_OWNERSHIP_TIMEOUT="${DB_OWNERSHIP_TIMEOUT:-600000}"
+    echo "Full preload/render stress: page_limit=$BONFIRE_FULL_RENDER_PAGE_LIMIT hidden_multiplier=$BONFIRE_FULL_RENDER_HIDDEN_MULTIPLIER hidden_extra_rows=$BONFIRE_FULL_RENDER_HIDDEN_EXTRA_ROWS preload_max_ms=$BONFIRE_FULL_PRELOAD_MAX_MS component_render_max_ms=$BONFIRE_FULL_COMPONENT_RENDER_MAX_MS initial_render_max_ms=$BONFIRE_FULL_INITIAL_RENDER_MAX_MS load_more_render_max_ms=$BONFIRE_FULL_LOAD_MORE_RENDER_MAX_MS"
+    run_test ../bonfire_ui_social/test/views/pagination/feed_full_preload_render_stress_test.exs
+    ;;
+  ui-browser-js)
+    export MIX_TEST_ONLY=ui
+    export PHX_SERVER=yes
+    export HOSTNAME="${HOSTNAME:-127.0.0.1}"
+    export SERVER_PORT="${SERVER_PORT:-4011}"
+    export PUBLIC_PORT="${PUBLIC_PORT:-$SERVER_PORT}"
+    run_test ../bonfire_ui_social/test/views/pagination/feed_browser_js_time_limit_test.exs --only browser_js
+    ;;
+  classic-benchmark)
+    unset MIX_TEST_ONLY
+    run_mix run benchmarks/classic_feed_benchmark.exs
+    ;;
+  classic-benchmark-stress)
+    unset MIX_TEST_ONLY
+    stress_database_url="${BONFIRE_CLASSIC_STRESS_DATABASE_URL:-ecto://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/bonfire_test_classic_stress}"
+    stress_url_path="${stress_database_url#*://}"
+    stress_url_auth_host="${stress_url_path%%/*}"
+    stress_database="${stress_url_path#*/}"
+    stress_database="${stress_database%%\?*}"
+    stress_host_port="${stress_url_auth_host##*@}"
+    stress_host="${stress_host_port%%:*}"
+    stress_port="$POSTGRES_PORT"
+    stress_auth=""
+    stress_user="$POSTGRES_USER"
+    stress_password="$POSTGRES_PASSWORD"
+
+    if [[ "$stress_host_port" == *:* ]]; then
+      stress_port="${stress_host_port##*:}"
+    fi
+
+    if [[ "$stress_url_auth_host" != "$stress_host_port" ]]; then
+      stress_auth="${stress_url_auth_host%@*}"
+    fi
+
+    if [[ -n "$stress_auth" ]]; then
+      if [[ "$stress_auth" == *:* ]]; then
+        stress_user="${stress_auth%%:*}"
+        stress_password="${stress_auth#*:}"
+      else
+        stress_user="$stress_auth"
+      fi
+    fi
+
+    if [[ "$stress_database" != *"_test"* ]]; then
+      echo "Refusing to run stress benchmark against a database that does not look like a test database." >&2
+      exit 64
+    fi
+
+    if [[ ! "$stress_database" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+      echo "Refusing stress database name with unsafe characters: $stress_database" >&2
+      exit 64
+    fi
+
+    drop_stress_database() {
+      if PGPASSWORD="$POSTGRES_PASSWORD" psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
+        -U "$POSTGRES_USER" -d postgres -AtqX -v ON_ERROR_STOP=1 \
+        -c "select 1 from pg_database where datname = '$POSTGRES_DB'" | grep -qx 1; then
+        PGPASSWORD="$POSTGRES_PASSWORD" dropdb --force \
+          -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" "$POSTGRES_DB"
+      fi
+    }
+
+    export DATABASE_URL="$stress_database_url"
+    export POSTGRES_USER="$stress_user"
+    export POSTGRES_PASSWORD="$stress_password"
+    export POSTGRES_HOST="${stress_host:-localhost}"
+    export POSTGRES_PORT="$stress_port"
+    export POSTGRES_DB="$stress_database"
+    export BONFIRE_CLASSIC_FEED_ROWS="${BONFIRE_CLASSIC_FEED_ROWS:-1000000}"
+    export BONFIRE_CLASSIC_EXACT_FEED_PUBLISH_ROWS="${BONFIRE_CLASSIC_EXACT_FEED_PUBLISH_ROWS:-$BONFIRE_CLASSIC_FEED_ROWS}"
+    export BONFIRE_CLASSIC_LOCAL_EVERY="${BONFIRE_CLASSIC_LOCAL_EVERY:-493}"
+    export BONFIRE_CLASSIC_HIDDEN_LOCAL_EVERY="${BONFIRE_CLASSIC_HIDDEN_LOCAL_EVERY:-23}"
+    export BONFIRE_CLASSIC_HIDDEN_LOCAL_BURST_ROWS="${BONFIRE_CLASSIC_HIDDEN_LOCAL_BURST_ROWS:-5000}"
+    export BONFIRE_CLASSIC_FETCHER_EVERY="${BONFIRE_CLASSIC_FETCHER_EVERY:-389}"
+    export BONFIRE_CLASSIC_CHURN_ROWS="${BONFIRE_CLASSIC_CHURN_ROWS:-250000}"
+    export BONFIRE_CLASSIC_VACUUM_AFTER_CHURN="${BONFIRE_CLASSIC_VACUUM_AFTER_CHURN:-1}"
+    export BONFIRE_CLASSIC_VACUUM_AFTER_SEED="${BONFIRE_CLASSIC_VACUUM_AFTER_SEED:-1}"
+    export BONFIRE_CLASSIC_SEED_BATCH="${BONFIRE_CLASSIC_SEED_BATCH:-25000}"
+    export BONFIRE_CLASSIC_FAST_SEED="${BONFIRE_CLASSIC_FAST_SEED:-1}"
+    export BONFIRE_CLASSIC_BENCH_WARMUP_RUNS="${BONFIRE_CLASSIC_BENCH_WARMUP_RUNS:-1}"
+    export BONFIRE_CLASSIC_BENCH_ITERATIONS="${BONFIRE_CLASSIC_BENCH_ITERATIONS:-3}"
+    export BONFIRE_CLASSIC_REQUIRED_PAGES="${BONFIRE_CLASSIC_REQUIRED_PAGES:-90}"
+    export BONFIRE_CLASSIC_EXPLAIN_PAGE="${BONFIRE_CLASSIC_EXPLAIN_PAGE:-90}"
+    export BONFIRE_CLASSIC_KEEP_ROWS=1
+    export BONFIRE_CLASSIC_REQUIRE_TARGET_INDEX="${BONFIRE_CLASSIC_REQUIRE_TARGET_INDEX:-1}"
+    export BONFIRE_CLASSIC_REQUIRE_NO_FEED_PUBLISH_SEQ_SCAN="${BONFIRE_CLASSIC_REQUIRE_NO_FEED_PUBLISH_SEQ_SCAN:-1}"
+    export BONFIRE_CLASSIC_REQUIRE_NO_TEMP_BLOCKS="${BONFIRE_CLASSIC_REQUIRE_NO_TEMP_BLOCKS:-1}"
+    export BONFIRE_CLASSIC_REQUIRE_FULL_PAGE="${BONFIRE_CLASSIC_REQUIRE_FULL_PAGE:-1}"
+    export BONFIRE_CLASSIC_MIN_VISIBLE_LOCAL_ROWS="${BONFIRE_CLASSIC_MIN_VISIBLE_LOCAL_ROWS:-2000}"
+    export BONFIRE_CLASSIC_MIN_HIDDEN_LOCAL_ROWS="${BONFIRE_CLASSIC_MIN_HIDDEN_LOCAL_ROWS:-40000}"
+    export BONFIRE_CLASSIC_MAX_FEED_PUBLISH_ACTUAL_ROWS="${BONFIRE_CLASSIC_MAX_FEED_PUBLISH_ACTUAL_ROWS:-75000}"
+    export BONFIRE_CLASSIC_MAX_FEED_PUBLISH_HEAP_FETCHES="${BONFIRE_CLASSIC_MAX_FEED_PUBLISH_HEAP_FETCHES:-1000}"
+    export BONFIRE_CLASSIC_MAX_FEED_PUBLISH_ROWS_REMOVED_BY_FILTER="${BONFIRE_CLASSIC_MAX_FEED_PUBLISH_ROWS_REMOVED_BY_FILTER:-50000}"
+    export BONFIRE_CLASSIC_MAX_FIRST_MS="${BONFIRE_CLASSIC_MAX_FIRST_MS:-222}"
+    export BONFIRE_CLASSIC_MAX_P95_MS="${BONFIRE_CLASSIC_MAX_P95_MS:-222}"
+    export BONFIRE_CLASSIC_MAX_PAGE_MS="${BONFIRE_CLASSIC_MAX_PAGE_MS:-222}"
+    export BONFIRE_CLASSIC_MAX_PAGE_P95_MS="${BONFIRE_CLASSIC_MAX_PAGE_P95_MS:-222}"
+    export BONFIRE_CLASSIC_BENCH_WORK_MEM="${BONFIRE_CLASSIC_BENCH_WORK_MEM:-4MB}"
+    export BONFIRE_CLASSIC_BENCH_EFFECTIVE_CACHE_SIZE="${BONFIRE_CLASSIC_BENCH_EFFECTIVE_CACHE_SIZE:-128MB}"
+    export BONFIRE_CLASSIC_BENCH_RANDOM_PAGE_COST="${BONFIRE_CLASSIC_BENCH_RANDOM_PAGE_COST:-4}"
+    export BONFIRE_CLASSIC_STRESS_TIMEOUT_SECONDS="${BONFIRE_CLASSIC_STRESS_TIMEOUT_SECONDS:-1800}"
+    export DB_QUERY_TIMEOUT="${DB_QUERY_TIMEOUT:-600000}"
+    export DB_STATEMENT_TIMEOUT="${DB_STATEMENT_TIMEOUT:-0}"
+    export DB_IDLE_TRANSACTION_TIMEOUT="${DB_IDLE_TRANSACTION_TIMEOUT:-600000}"
+    export DB_POOL_TIMEOUT="${DB_POOL_TIMEOUT:-600000}"
+    export DB_OWNERSHIP_TIMEOUT="${DB_OWNERSHIP_TIMEOUT:-600000}"
+    drop_stress_database
+    trap 'drop_stress_database' EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+    stress_status=0
+    run_mix_with_timeout "$BONFIRE_CLASSIC_STRESS_TIMEOUT_SECONDS" run benchmarks/classic_feed_benchmark.exs || stress_status=$?
+    trap - EXIT INT TERM
+    drop_stress_database
+    exit "$stress_status"
+    ;;
+  classic-benchmark-local-heavy)
+    export BONFIRE_CLASSIC_STRESS_DATABASE_URL="${BONFIRE_CLASSIC_LOCAL_HEAVY_DATABASE_URL:-ecto://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/bonfire_test_classic_local_heavy}"
+    export BONFIRE_CLASSIC_FEED_ROWS="${BONFIRE_CLASSIC_FEED_ROWS:-1000000}"
+    export BONFIRE_CLASSIC_EXACT_FEED_PUBLISH_ROWS="${BONFIRE_CLASSIC_EXACT_FEED_PUBLISH_ROWS:-$BONFIRE_CLASSIC_FEED_ROWS}"
+    export BONFIRE_CLASSIC_LOCAL_EVERY="${BONFIRE_CLASSIC_LOCAL_EVERY:-1}"
+    export BONFIRE_CLASSIC_HIDDEN_LOCAL_EVERY="${BONFIRE_CLASSIC_HIDDEN_LOCAL_EVERY:-0}"
+    export BONFIRE_CLASSIC_HIDDEN_LOCAL_BURST_ROWS="${BONFIRE_CLASSIC_HIDDEN_LOCAL_BURST_ROWS:-0}"
+    export BONFIRE_CLASSIC_FETCHER_EVERY="${BONFIRE_CLASSIC_FETCHER_EVERY:-0}"
+    export BONFIRE_CLASSIC_MIN_VISIBLE_LOCAL_ROWS="${BONFIRE_CLASSIC_MIN_VISIBLE_LOCAL_ROWS:-$BONFIRE_CLASSIC_FEED_ROWS}"
+    export BONFIRE_CLASSIC_MIN_HIDDEN_LOCAL_ROWS="${BONFIRE_CLASSIC_MIN_HIDDEN_LOCAL_ROWS:-0}"
+    export BONFIRE_CLASSIC_REQUIRE_TARGET_INDEX="${BONFIRE_CLASSIC_REQUIRE_TARGET_INDEX:-0}"
+    exec "$0" classic-benchmark-stress
+    ;;
+  classic-benchmark-guest-visible-acl-stress)
+    export BONFIRE_CLASSIC_STRESS_DATABASE_URL="${BONFIRE_CLASSIC_GUEST_ACL_DATABASE_URL:-ecto://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/bonfire_test_classic_guest_acl_stress}"
+    export BONFIRE_CLASSIC_VISIBLE_ACL="${BONFIRE_CLASSIC_VISIBLE_ACL:-guests_may_see_read}"
+    export BONFIRE_CLASSIC_FEED_ROWS="${BONFIRE_CLASSIC_FEED_ROWS:-1000000}"
+    export BONFIRE_CLASSIC_EXACT_FEED_PUBLISH_ROWS="${BONFIRE_CLASSIC_EXACT_FEED_PUBLISH_ROWS:-$BONFIRE_CLASSIC_FEED_ROWS}"
+    export BONFIRE_CLASSIC_LOCAL_EVERY="${BONFIRE_CLASSIC_LOCAL_EVERY:-37}"
+    export BONFIRE_CLASSIC_HIDDEN_LOCAL_EVERY="${BONFIRE_CLASSIC_HIDDEN_LOCAL_EVERY:-5}"
+    export BONFIRE_CLASSIC_HIDDEN_LOCAL_BURST_ROWS="${BONFIRE_CLASSIC_HIDDEN_LOCAL_BURST_ROWS:-100000}"
+    export BONFIRE_CLASSIC_FETCHER_EVERY="${BONFIRE_CLASSIC_FETCHER_EVERY:-97}"
+    export BONFIRE_CLASSIC_MIN_VISIBLE_LOCAL_ROWS="${BONFIRE_CLASSIC_MIN_VISIBLE_LOCAL_ROWS:-20000}"
+    export BONFIRE_CLASSIC_MIN_HIDDEN_LOCAL_ROWS="${BONFIRE_CLASSIC_MIN_HIDDEN_LOCAL_ROWS:-250000}"
+    export BONFIRE_CLASSIC_REQUIRED_PAGES="${BONFIRE_CLASSIC_REQUIRED_PAGES:-120}"
+    export BONFIRE_CLASSIC_EXPLAIN_PAGE="${BONFIRE_CLASSIC_EXPLAIN_PAGE:-1}"
+    export BONFIRE_CLASSIC_BENCH_WORK_MEM="${BONFIRE_CLASSIC_BENCH_WORK_MEM:-1MB}"
+    export BONFIRE_CLASSIC_BENCH_EFFECTIVE_CACHE_SIZE="${BONFIRE_CLASSIC_BENCH_EFFECTIVE_CACHE_SIZE:-64MB}"
+    export BONFIRE_CLASSIC_BENCH_RANDOM_PAGE_COST="${BONFIRE_CLASSIC_BENCH_RANDOM_PAGE_COST:-4}"
+    exec "$0" classic-benchmark-stress
+    ;;
+  all-with-benchmark)
+    "$0" all
+    "$0" ui-full-preload-render-stress
+    "$0" ui-browser-js
+    "$0" classic-benchmark-stress
+    ;;
+  all-with-strict-benchmark)
+    "$0" all
+    "$0" ui-full-preload-render-stress
+    "$0" ui-browser-js
+    "$0" classic-benchmark-stress
+    "$0" classic-benchmark-local-heavy
+    "$0" classic-benchmark-guest-visible-acl-stress
+    ;;
+  all)
+    "$0" format
+    "$0" backend
+    "$0" ui
+    "$0" ui-presets
+    "$0" ui-context
+    "$0" ui-auto-short-feed
+    "$0" ui-actual-cases
+    "$0" ui-time-limit
+    "$0" ui-benchmark-target
+    ;;
+  *)
+    echo "Usage: $0 [format|backend|ui|ui-presets|ui-context|ui-auto-short-feed|ui-actual-cases|ui-time-limit|ui-benchmark-target|ui-full-preload-render-stress|ui-browser-js|classic-benchmark|classic-benchmark-stress|classic-benchmark-local-heavy|classic-benchmark-guest-visible-acl-stress|all|all-with-benchmark|all-with-strict-benchmark]" >&2
+    exit 64
+    ;;
+esac

--- a/test/support/lightweight_test_application.ex
+++ b/test/support/lightweight_test_application.ex
@@ -1,0 +1,118 @@
+defmodule Bonfire.LightweightTestApplication do
+  @moduledoc false
+
+  use Application
+
+  @template_root Path.expand("../../extensions/ember/priv/templates/lib", __DIR__)
+  @generated_modules [
+    "bonfire/bonfire.ex",
+    "bonfire/localise.ex",
+    "bonfire/postgres_types.ex",
+    "bonfire/seeder.ex"
+  ]
+  @test_apps [:ecto, :db_connection, :postgrex, :ecto_sql, :phoenix_pubsub]
+
+  def enabled?, do: System.get_env("BONFIRE_LIGHTWEIGHT_TEST_SETUP") == "1"
+
+  def start(type, args) do
+    if ui_tests?() do
+      ensure_generated_modules!()
+      apply(Bonfire.Application, :start, [type, args])
+    else
+      Supervisor.start_link([], strategy: :one_for_one, name: __MODULE__.Supervisor)
+    end
+  end
+
+  def config_change(changed, new, removed) do
+    if Code.ensure_loaded?(Bonfire.Application) do
+      apply(Bonfire.Application, :config_change, [changed, new, removed])
+    else
+      :ok
+    end
+  end
+
+  def setup_test! do
+    maybe_start_bonfire()
+    Enum.each(@test_apps, &Application.ensure_all_started/1)
+    ensure_pubsub_started()
+    maybe_migrate_repo()
+    start_ex_unit()
+  end
+
+  def ensure_generated_modules! do
+    unless Code.ensure_loaded?(Bonfire.Application) and Code.ensure_loaded?(Bonfire.Web.Endpoint) do
+      @generated_modules
+      |> Enum.map(&Path.join(@template_root, &1))
+      |> Kernel.++(Path.wildcard(Path.join(@template_root, "bonfire/web/views/**/*.ex")))
+      |> Kernel.++([
+        Path.join(@template_root, "bonfire/web/router/routes.ex"),
+        Path.join(@template_root, "bonfire/web/endpoint.ex"),
+        Path.join(@template_root, "bonfire/web/fake_remote_endpoint.ex"),
+        Path.join(@template_root, "bonfire/application.ex")
+      ])
+      |> Enum.each(fn file ->
+        if File.exists?(file), do: Code.compile_file(file)
+      end)
+    end
+  end
+
+  defp ui_tests?, do: System.get_env("MIX_TEST_ONLY") == "ui"
+
+  defp maybe_start_bonfire do
+    if ui_tests?() do
+      Mix.Task.run("ecto.create")
+      Application.ensure_all_started(:bonfire)
+    end
+  end
+
+  defp ensure_pubsub_started do
+    unless Process.whereis(Bonfire.Common.PubSub) do
+      Supervisor.start_link(
+        [{Phoenix.PubSub, name: Bonfire.Common.PubSub}],
+        strategy: :one_for_one
+      )
+    end
+  end
+
+  defp maybe_migrate_repo do
+    if System.get_env("BONFIRE_LIGHTWEIGHT_TEST_MIGRATE") == "1" do
+      repo = Bonfire.Common.Config.repo()
+
+      if repo do
+        Mix.Task.run("ecto.create")
+        start_repo(repo)
+        Mix.Task.run("ecto.migrate")
+        run_extension_migrations_strict!(repo)
+        Ecto.Adapters.SQL.Sandbox.mode(repo, :auto)
+      end
+    end
+  end
+
+  defp run_extension_migrations_strict!(repo) do
+    results = EctoSparkles.Migrator.migrate_repo(repo, continue_on_error: true)
+    failures = Enum.reject(results, &match?({:ok, _version, _desc}, &1))
+
+    case failures do
+      [] -> :ok
+      failures -> raise "Extension migrations failed: #{inspect(failures)}"
+    end
+  end
+
+  defp start_repo(repo) do
+    case repo.start_link() do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
+  end
+
+  defp start_ex_unit do
+    ExUnit.configure(
+      timeout: 120_000,
+      assert_receive_timeout: 1000,
+      exclude: Bonfire.Common.RuntimeConfig.skip_test_tags(),
+      capture_log: System.get_env("CAPTURE_LOG") != "no"
+    )
+
+    ExUnit.start()
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,5 @@
-Bonfire.Common.Testing.configure_start_test(migrate: true)
+if Bonfire.LightweightTestApplication.enabled?() do
+  Bonfire.LightweightTestApplication.setup_test!()
+else
+  Bonfire.Common.Testing.configure_start_test(migrate: true)
+end


### PR DESCRIPTION
## Summary

Part 5 of the Bonfire feed query performance stack for bonfire-networks/bounties#1.

This adds the app-level harness used to validate the local feed query work across sibling Bonfire extensions:

- Add `test-pagination-regression.sh` as the reproducible local entrypoint.
- Add strict Classic feed benchmark profiles.
- Wire the lightweight test app setup needed by the sibling extension tests.
- Document the dependency order and strict benchmark targets.

## Stack

1. bonfire_common: https://github.com/bonfire-networks/bonfire_common/pull/15
2. bonfire_data_social: https://github.com/bonfire-networks/bonfire_data_social/pull/5
3. bonfire_social: https://github.com/bonfire-networks/bonfire_social/pull/7
4. bonfire_ui_social: https://github.com/bonfire-networks/bonfire_ui_social/pull/9
5. bonfire-app: https://github.com/bonfire-networks/bonfire-app/pull/1994

## Why

The bounty requires reducing the Classic guest local feed query for 20 activities with no time filter below 222 ms. The harness makes that claim testable locally against strict synthetic datasets and UI/browser stress paths, while still leaving official campground verification to maintainers.

The harness does not claim to replace the maintainer `feed_backend` run on campground.

## Validation

Final strict local gate:

```bash
BONFIRE_FULL_RENDER_HIDDEN_MULTIPLIER=128 BONFIRE_FULL_RENDER_HIDDEN_EXTRA_ROWS=25 ./test-pagination-regression.sh all-with-strict-benchmark
```

Result: passed locally in about 15.2 minutes.

Key local results:

- Backend regression: `17 tests, 0 failures (1 excluded)`.
- Browser JS block: `2 tests, 0 failures`.
- Classic sparse stress, 1,000,000 rows: `cold_first_timing_ms=48.98`, `page_max_ms=97.14`, `page_p95_ms=91.5`.
- All-local heavy, 1,000,000 rows: `cold_first_timing_ms=30.04`, `page_max_ms=17.56`, `page_p95_ms=14.64`.
- Guest-visible ACL stress, 1,000,000 rows: `cold_first_timing_ms=48.93`, `page_max_ms=43.68`, `page_p95_ms=40.99`.
- Full preload/render stress:
  - `first_preload_ms=194.47`
  - `second_preload_ms=164.74`
  - `initial_render_ms=977.3`
  - `load_more_render_ms=550.31`

Additional local check:

- `git diff --check origin/main..HEAD`

## Known Limits

I do not have the campground database or maintainer hardware, so I am not claiming the official `feed_backend` benchmark has passed. That still needs maintainer verification on campground.
