### PR TITLE
docs: fix typos in AGENTS, HACKING and topic docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Act as a thoughtful and cooperative companion rather than an independent worker:
 - **Feature-Based Organization**: Group related functionality by feature domain within non-UI extensions, while UI extensions use web framework conventions (components, views, controllers, etc.).
 - **Layered Architecture**: Each layer has a clear responsibility:
   - **`bonfire_data_*`** — Ecto schemas, changesets, and migrations only. No business logic or queries.
-  - **Domain contexts** (e.g. `bonfire_social_graph`, `bonfire_me`) — Own the business rules and query logic for their domain (though sometimes there's a seperate query module). Expose reusable helpers that other modules can compose.
+  - **Domain contexts** (e.g. `bonfire_social_graph`, `bonfire_me`) — Own the business rules and query logic for their domain (though sometimes there's a separate query module). Expose reusable helpers that other modules can compose.
   - **`bonfire_ui_*`** — UI components and widgets. Call into contexts/integrations for data, never implement non-UI-logic or build queries directly.
 - **Query ownership**: A query about a domain concept (follows, blocks, posts) belongs in that domain's context module, even if it's consumed by another extension. The consuming extension should call the helper, not rewrite the query. For example, a follow-related query belongs in `Follows` even if `Instances` needs the result — `Instances` calls `Follows` and wraps with its own aggregation.
 - **Enabling/disabling modules**: Use the standard modularity config key `[:otp_app, MyModule, :modularity]` set to `:disabled` — not a custom `:enabled` flag.

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -108,7 +108,7 @@ You may also want to put this in the appropriate place in your system so your ch
 
 > #### Info {: .info}
 >
-> Note: you can use a tool like [mise](https://mise.jdx.dev/) or asdf to setup the environment (run `mise install` in the root directory). You will still need to install Postgres and Meili seperately though.
+> Note: you can use a tool like [mise](https://mise.jdx.dev/) or asdf to setup the environment (run `mise install` in the root directory). You will still need to install Postgres and Meili separately though.
 
 - Dependencies:
   - Recent versions of [Elixir](https://elixir-lang.org/install.html) (1.15+) and OTP/erlang (25+)

--- a/docs/topics/PHOENIX_TEST.md
+++ b/docs/topics/PHOENIX_TEST.md
@@ -38,7 +38,7 @@ defmodule MyAppWeb.AdminCanCreateUserTest do
 end
 copy
 Filling out forms
-We can fill out forms by targetting their inputs, selects, etc. by label:
+We can fill out forms by targeting their inputs, selects, etc. by label:
 
 test "admin can create user", %{conn: conn} do
   conn
@@ -105,7 +105,7 @@ Clicks a link with given text (using a substring match) and performs the action.
 click_link(session, selector, text)
 Clicks a link with given CSS selector and text and performs the action. selector to target the link.
 fill_in(session, label, opts)
-Fills text inputs and textareas, targetting the elements by their labels.
+Fills text inputs and textareas, targeting the elements by their labels.
 fill_in(session, input_selector, label, opts)
 Like fill_in/3 but you can specify an input's selector (in addition to the label).
 open_browser(session)

--- a/docs/topics/federation-interoperability.md
+++ b/docs/topics/federation-interoperability.md
@@ -99,7 +99,7 @@ Partial support or conformity to-be-confirmed (help needed!):
 - [FEP-c16b][37] (Formatting MFM functions)
 - [FEP-eb48][38] (Hashtags)
 
-Work-in-progres, planned, or exploring (suggestions/feedback welcome!):
+Work-in-progress, planned, or exploring (suggestions/feedback welcome!):
 - [FEP-1b12][15] (Group federation)
 - [FEP-67ff][39] (FEDERATION.md)
 - [FEP-2677][40] (Identifying the Application Actor)


### PR DESCRIPTION
Five typo fixes:

- `AGENTS.md:40` — `seperate` → `separate`
- `docs/HACKING.md:111` — `seperately` → `separately`
- `docs/topics/PHOENIX_TEST.md:41` and `:108` — `targetting` → `targeting`
- `docs/topics/federation-interoperability.md:102` — "Work-in-progres" → "progress"

Docs only.
